### PR TITLE
feat(admin): complete admin dashboard with auth and CRUD editors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,11 @@
       "name": "portfolio",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@gsap/react": "^2.1.2",
+        "@hookform/resolvers": "^5.2.2",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.95.2",
         "class-variance-authority": "^0.7.1",
@@ -22,6 +26,7 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "react-hook-form": "^7.71.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "zod": "^4.3.6"
@@ -291,6 +296,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -958,6 +1016,18 @@
       "peerDependencies": {
         "gsap": "^3.12.5",
         "react": ">=17"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3236,6 +3306,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -7844,6 +7920,22 @@
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.71.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
+      "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@gsap/react": "^2.1.2",
+    "@hookform/resolvers": "^5.2.2",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.2",
     "class-variance-authority": "^0.7.1",
@@ -23,6 +27,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-hook-form": "^7.71.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.3.6"

--- a/src/app/admin/about/about-form.tsx
+++ b/src/app/admin/about/about-form.tsx
@@ -1,0 +1,170 @@
+"use client"
+
+import { useTransition } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { toast } from "sonner"
+import { aboutSchema, type AboutFormValues } from "@/lib/schemas/about"
+import { updateAbout } from "./actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { FormSection } from "@/components/admin/form-section"
+import { DynamicList } from "@/components/admin/dynamic-list"
+import { DynamicKeyValueList } from "@/components/admin/dynamic-key-value-list"
+import { ImageUpload } from "@/components/admin/image-upload"
+import type { AboutSection } from "@/types/database"
+
+interface AboutFormProps {
+  data: AboutSection
+}
+
+export function AboutForm({ data }: AboutFormProps) {
+  const [isPending, startTransition] = useTransition()
+
+  const form = useForm<AboutFormValues>({
+    resolver: zodResolver(aboutSchema),
+    defaultValues: {
+      heading: data.heading ?? "",
+      subheading: data.subheading ?? "",
+      bio: data.bio,
+      bio_secondary: data.bio_secondary ?? "",
+      portrait_url: data.portrait_url ?? "",
+      stats: data.stats ?? [],
+      tech_stack: data.tech_stack ?? [],
+    },
+  })
+
+  function onSubmit(values: AboutFormValues) {
+    startTransition(async () => {
+      const result = await updateAbout(values)
+      if (result?.error) {
+        toast.error(result.error)
+      } else {
+        toast.success("About section updated")
+      }
+    })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormSection title="Content">
+          <FormField
+            control={form.control}
+            name="heading"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Heading</FormLabel>
+                <FormControl><Input placeholder="About Me" {...field} value={field.value ?? ""} /></FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="subheading"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Subheading</FormLabel>
+                <FormControl><Input {...field} value={field.value ?? ""} /></FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="bio"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Bio</FormLabel>
+                <FormControl><Textarea rows={5} {...field} /></FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="bio_secondary"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Secondary Bio</FormLabel>
+                <FormControl><Textarea rows={3} {...field} value={field.value ?? ""} /></FormControl>
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <FormSection title="Portrait">
+          <FormField
+            control={form.control}
+            name="portrait_url"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Portrait Image</FormLabel>
+                <FormControl>
+                  <ImageUpload
+                    value={field.value || null}
+                    onChange={(url) => field.onChange(url ?? "")}
+                    bucket="avatars"
+                    path="about"
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <FormSection title="Stats" description="Key metrics displayed in the about section">
+          <FormField
+            control={form.control}
+            name="stats"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <DynamicKeyValueList
+                    items={field.value ?? []}
+                    onChange={field.onChange}
+                    keyLabel="Label"
+                    valueLabel="Value"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <FormSection title="Tech Stack">
+          <FormField
+            control={form.control}
+            name="tech_stack"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <DynamicList
+                    items={field.value ?? []}
+                    onChange={field.onChange}
+                    placeholder="Add technology..."
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "Saving..." : "Save Changes"}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/src/app/admin/about/actions.ts
+++ b/src/app/admin/about/actions.ts
@@ -1,0 +1,22 @@
+"use server"
+
+import { revalidateTag, revalidatePath } from "next/cache"
+import { createClient } from "@/lib/supabase/server"
+import { requireAuth } from "@/lib/admin-auth"
+import { aboutSchema, type AboutFormValues } from "@/lib/schemas/about"
+
+export async function updateAbout(data: AboutFormValues) {
+  await requireAuth()
+  const validated = aboutSchema.parse(data)
+  const supabase = await createClient()
+
+  const { data: current } = await supabase.from("about_section").select("id").single()
+  if (!current) return { error: "About section not found" }
+
+  const { error } = await supabase.from("about_section").update(validated).eq("id", current.id)
+  if (error) return { error: error.message }
+
+  revalidateTag("about", "max")
+  revalidatePath("/")
+  return { success: true }
+}

--- a/src/app/admin/about/page.tsx
+++ b/src/app/admin/about/page.tsx
@@ -1,0 +1,29 @@
+import { createClient } from "@/lib/supabase/server"
+import { AdminHeader } from "../admin-header"
+import { AboutForm } from "./about-form"
+import type { AboutSection } from "@/types/database"
+
+export default async function AboutPage() {
+  const supabase = await createClient()
+  const { data } = await supabase.from("about_section").select("*").single()
+
+  if (!data) {
+    return (
+      <>
+        <AdminHeader title="About" />
+        <div className="p-4 md:p-6">
+          <p className="text-muted-foreground">No about section found. Run the seed script first.</p>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <AdminHeader title="About" />
+      <div className="p-4 md:p-6 max-w-3xl">
+        <AboutForm data={data as AboutSection} />
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -1,0 +1,10 @@
+"use server"
+
+import { redirect } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
+
+export async function logout() {
+  const supabase = await createClient()
+  await supabase.auth.signOut()
+  redirect("/login")
+}

--- a/src/app/admin/admin-header.tsx
+++ b/src/app/admin/admin-header.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { useState } from "react"
+import { Menu } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Sheet, SheetContent, SheetTrigger, SheetTitle } from "@/components/ui/sheet"
+import { AdminSidebar } from "./admin-sidebar"
+
+interface AdminHeaderProps {
+  title: string
+  unreadCount?: number
+}
+
+export function AdminHeader({ title, unreadCount }: AdminHeaderProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <header className="sticky top-0 z-40 flex h-14 items-center gap-4 border-b bg-background px-4 md:px-6">
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetTrigger asChild>
+          <Button variant="ghost" size="icon" className="md:hidden">
+            <Menu className="h-5 w-5" />
+            <span className="sr-only">Toggle menu</span>
+          </Button>
+        </SheetTrigger>
+        <SheetContent side="left" className="w-64 p-0">
+          <SheetTitle className="sr-only">Navigation</SheetTitle>
+          <div onClick={() => setOpen(false)}>
+            <AdminSidebar unreadCount={unreadCount} />
+          </div>
+        </SheetContent>
+      </Sheet>
+      <h1 className="text-lg font-semibold">{title}</h1>
+    </header>
+  )
+}

--- a/src/app/admin/admin-sidebar.tsx
+++ b/src/app/admin/admin-sidebar.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { useTransition } from "react"
+import {
+  LayoutDashboard,
+  Sparkles,
+  User,
+  FolderKanban,
+  Wrench,
+  Briefcase,
+  FileText,
+  FileDown,
+  MessageSquare,
+  Settings,
+  ExternalLink,
+  LogOut,
+} from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { logout } from "./actions"
+
+const navItems = [
+  { href: "/admin", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/admin/hero", label: "Hero", icon: Sparkles },
+  { href: "/admin/about", label: "About", icon: User },
+  { href: "/admin/projects", label: "Projects", icon: FolderKanban },
+  { href: "/admin/skills", label: "Skills", icon: Wrench },
+  { href: "/admin/experience", label: "Experience", icon: Briefcase },
+  { href: "/admin/blog", label: "Blog", icon: FileText },
+  { href: "/admin/resume", label: "Resume", icon: FileDown },
+  { href: "/admin/messages", label: "Messages", icon: MessageSquare },
+  { href: "/admin/settings", label: "Settings", icon: Settings },
+]
+
+interface AdminSidebarProps {
+  unreadCount?: number
+}
+
+export function AdminSidebar({ unreadCount = 0 }: AdminSidebarProps) {
+  const pathname = usePathname()
+  const [isPending, startTransition] = useTransition()
+
+  function isActive(href: string) {
+    if (href === "/admin") return pathname === "/admin"
+    return pathname.startsWith(href)
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-14 items-center border-b px-4">
+        <Link href="/admin" className="flex items-center gap-2 font-semibold">
+          <span className="text-lg">Portfolio</span>
+          <Badge variant="secondary" className="text-xs">Admin</Badge>
+        </Link>
+      </div>
+      <ScrollArea className="flex-1 px-3 py-4">
+        <nav className="flex flex-col gap-1">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                isActive(item.href)
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              )}
+            >
+              <item.icon className="h-4 w-4" />
+              {item.label}
+              {item.label === "Messages" && unreadCount > 0 && (
+                <Badge variant="destructive" className="ml-auto h-5 min-w-5 px-1 text-xs">
+                  {unreadCount}
+                </Badge>
+              )}
+            </Link>
+          ))}
+        </nav>
+      </ScrollArea>
+      <div className="border-t p-3 space-y-1">
+        <Link
+          href="/"
+          target="_blank"
+          className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+        >
+          <ExternalLink className="h-4 w-4" />
+          View Site
+        </Link>
+        <Button
+          variant="ghost"
+          className="w-full justify-start gap-3 px-3 text-muted-foreground"
+          onClick={() => startTransition(() => logout())}
+          disabled={isPending}
+        >
+          <LogOut className="h-4 w-4" />
+          {isPending ? "Signing out..." : "Logout"}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/blog/page.tsx
+++ b/src/app/admin/blog/page.tsx
@@ -1,0 +1,20 @@
+import { AdminHeader } from "../admin-header"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { FileText } from "lucide-react"
+
+export default function BlogAdminPage() {
+  return (
+    <>
+      <AdminHeader title="Blog" />
+      <div className="p-4 md:p-6 max-w-3xl">
+        <Alert>
+          <FileText className="h-4 w-4" />
+          <AlertTitle>Coming Soon</AlertTitle>
+          <AlertDescription>
+            Blog management will be implemented in Issue #3.
+          </AlertDescription>
+        </Alert>
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/contact/actions.ts
+++ b/src/app/admin/contact/actions.ts
@@ -1,0 +1,38 @@
+"use server"
+
+import { revalidateTag, revalidatePath } from "next/cache"
+import { createClient } from "@/lib/supabase/server"
+import { requireAuth } from "@/lib/admin-auth"
+import { z } from "zod"
+
+const contactInfoSchema = z.object({
+  contact_email: z.string().email().nullable().or(z.literal("")).transform(v => v || null),
+  contact_form_enabled: z.boolean(),
+  social_links: z.record(z.string(), z.string()),
+})
+
+export type ContactInfoFormValues = z.input<typeof contactInfoSchema>
+
+export async function updateContactInfo(data: ContactInfoFormValues) {
+  await requireAuth()
+  const validated = contactInfoSchema.parse(data)
+  const supabase = await createClient()
+
+  const { data: current } = await supabase.from("site_settings").select("id").single()
+  if (!current) return { error: "Site settings not found" }
+
+  const { error } = await supabase
+    .from("site_settings")
+    .update({
+      contact_email: validated.contact_email,
+      contact_form_enabled: validated.contact_form_enabled,
+      social_links: validated.social_links,
+    })
+    .eq("id", current.id)
+
+  if (error) return { error: error.message }
+
+  revalidateTag("site_settings", "max")
+  revalidatePath("/")
+  return { success: true }
+}

--- a/src/app/admin/contact/contact-form.tsx
+++ b/src/app/admin/contact/contact-form.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import { useTransition } from "react"
+import { useForm } from "react-hook-form"
+import { toast } from "sonner"
+import { updateContactInfo, type ContactInfoFormValues } from "./actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Switch } from "@/components/ui/switch"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormDescription,
+} from "@/components/ui/form"
+import { FormSection } from "@/components/admin/form-section"
+import { DynamicKeyValueList } from "@/components/admin/dynamic-key-value-list"
+import type { SiteSettings } from "@/types/database"
+
+interface ContactInfoFormProps {
+  data: SiteSettings
+}
+
+export function ContactInfoForm({ data }: ContactInfoFormProps) {
+  const [isPending, startTransition] = useTransition()
+
+  // Convert social_links from Record<string,string> to {label,value}[] for the UI
+  const socialLinksArray = Object.entries(data.social_links ?? {}).map(([label, value]) => ({
+    label,
+    value,
+  }))
+
+  const form = useForm<ContactInfoFormValues>({
+    defaultValues: {
+      contact_email: data.contact_email ?? "",
+      contact_form_enabled: data.contact_form_enabled,
+      social_links: data.social_links ?? {},
+    },
+  })
+
+  function onSubmit(values: ContactInfoFormValues) {
+    startTransition(async () => {
+      const result = await updateContactInfo(values)
+      if (result?.error) {
+        toast.error(result.error)
+      } else {
+        toast.success("Contact info updated")
+      }
+    })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormSection title="Contact Details">
+          <FormField
+            control={form.control}
+            name="contact_email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Contact Email</FormLabel>
+                <FormControl><Input type="email" placeholder="you@example.com" {...field} value={field.value ?? ""} /></FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="contact_form_enabled"
+            render={({ field }) => (
+              <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                <div>
+                  <FormLabel>Contact Form</FormLabel>
+                  <FormDescription>Allow visitors to send messages via the contact form</FormDescription>
+                </div>
+                <FormControl>
+                  <Switch checked={field.value} onCheckedChange={field.onChange} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <FormSection title="Social Links" description="Platform name and URL pairs">
+          <DynamicKeyValueList
+            items={socialLinksArray}
+            onChange={(items) => {
+              const record: Record<string, string> = {}
+              items.forEach(({ label, value }) => { if (label) record[label] = value })
+              form.setValue("social_links", record)
+            }}
+            keyLabel="Platform"
+            valueLabel="URL"
+          />
+        </FormSection>
+
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "Saving..." : "Save Changes"}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/src/app/admin/contact/page.tsx
+++ b/src/app/admin/contact/page.tsx
@@ -1,0 +1,29 @@
+import { createClient } from "@/lib/supabase/server"
+import { AdminHeader } from "../admin-header"
+import { ContactInfoForm } from "./contact-form"
+import type { SiteSettings } from "@/types/database"
+
+export default async function ContactInfoPage() {
+  const supabase = await createClient()
+  const { data } = await supabase.from("site_settings").select("*").single()
+
+  if (!data) {
+    return (
+      <>
+        <AdminHeader title="Contact Info" />
+        <div className="p-4 md:p-6">
+          <p className="text-muted-foreground">No site settings found. Run the seed script first.</p>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <AdminHeader title="Contact Info" />
+      <div className="p-4 md:p-6 max-w-3xl">
+        <ContactInfoForm data={data as SiteSettings} />
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/dashboard-cards.tsx
+++ b/src/app/admin/dashboard-cards.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import Link from "next/link"
+import { FolderKanban, Wrench, Briefcase, FileText, MessageSquare } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { ContactSubmission } from "@/types/database"
+
+interface DashboardCardsProps {
+  counts: {
+    projects: number
+    skills: number
+    experience: number
+    blog_posts: number
+    unread_messages: number
+  }
+  recentMessages: ContactSubmission[]
+}
+
+const statCards = [
+  { key: "projects" as const, label: "Projects", icon: FolderKanban, href: "/admin/projects" },
+  { key: "skills" as const, label: "Skills", icon: Wrench, href: "/admin/skills" },
+  { key: "experience" as const, label: "Experience", icon: Briefcase, href: "/admin/experience" },
+  { key: "blog_posts" as const, label: "Blog Posts", icon: FileText, href: "/admin/blog" },
+  { key: "unread_messages" as const, label: "Unread Messages", icon: MessageSquare, href: "/admin/messages" },
+]
+
+export function DashboardCards({ counts, recentMessages }: DashboardCardsProps) {
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        {statCards.map((card) => (
+          <Link key={card.key} href={card.href}>
+            <Card className="hover:bg-accent/50 transition-colors">
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">
+                  {card.label}
+                </CardTitle>
+                <card.icon className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{counts[card.key]}</div>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Recent Messages</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {recentMessages.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No messages yet</p>
+          ) : (
+            <div className="space-y-3">
+              {recentMessages.map((msg) => (
+                <div key={msg.id} className="flex items-start justify-between gap-4 text-sm">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium truncate">{msg.name}</span>
+                      {!msg.read && (
+                        <span className="h-2 w-2 rounded-full bg-blue-500 flex-shrink-0" />
+                      )}
+                    </div>
+                    <p className="text-muted-foreground truncate">{msg.subject || msg.message}</p>
+                  </div>
+                  <span className="text-xs text-muted-foreground whitespace-nowrap">
+                    {new Date(msg.created_at).toLocaleDateString()}
+                  </span>
+                </div>
+              ))}
+              <Link href="/admin/messages" className="text-sm text-primary hover:underline block pt-2">
+                View all messages
+              </Link>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/admin/experience/[id]/page.tsx
+++ b/src/app/admin/experience/[id]/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
+import { AdminHeader } from "../../admin-header"
+import { ExperienceForm } from "../experience-form"
+import type { Experience } from "@/types/database"
+
+export default async function EditExperiencePage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createClient()
+  const { data } = await supabase.from("experience").select("*").eq("id", id).single()
+
+  if (!data) notFound()
+
+  return (
+    <>
+      <AdminHeader title={`Edit: ${data.role} at ${data.company}`} />
+      <div className="p-4 md:p-6 max-w-3xl">
+        <ExperienceForm data={data as Experience} />
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/experience/actions.ts
+++ b/src/app/admin/experience/actions.ts
@@ -1,0 +1,69 @@
+"use server"
+
+import { revalidateTag, revalidatePath } from "next/cache"
+import { createClient } from "@/lib/supabase/server"
+import { requireAuth } from "@/lib/admin-auth"
+import { experienceSchema, type ExperienceFormValues } from "@/lib/schemas/experience"
+
+export async function createExperience(data: ExperienceFormValues) {
+  await requireAuth()
+  const validated = experienceSchema.parse(data)
+  const supabase = await createClient()
+
+  const { data: last } = await supabase
+    .from("experience")
+    .select("sort_order")
+    .order("sort_order", { ascending: false })
+    .limit(1)
+    .single()
+
+  const sort_order = (last?.sort_order ?? 0) + 1
+
+  const { error } = await supabase.from("experience").insert({ ...validated, sort_order })
+  if (error) return { error: error.message }
+
+  revalidateTag("experience", "max")
+  revalidatePath("/")
+  return { success: true }
+}
+
+export async function updateExperience(id: string, data: ExperienceFormValues) {
+  await requireAuth()
+  const validated = experienceSchema.parse(data)
+  const supabase = await createClient()
+
+  const { error } = await supabase.from("experience").update(validated).eq("id", id)
+  if (error) return { error: error.message }
+
+  revalidateTag("experience", "max")
+  revalidatePath("/")
+  return { success: true }
+}
+
+export async function deleteExperience(id: string) {
+  await requireAuth()
+  const supabase = await createClient()
+
+  const { error } = await supabase.from("experience").delete().eq("id", id)
+  if (error) return { error: error.message }
+
+  revalidateTag("experience", "max")
+  revalidatePath("/")
+  return { success: true }
+}
+
+export async function updateExperienceOrder(ids: string[]) {
+  await requireAuth()
+  const supabase = await createClient()
+
+  const updates = ids.map((id, index) =>
+    supabase.from("experience").update({ sort_order: index }).eq("id", id)
+  )
+
+  const results = await Promise.all(updates)
+  const failed = results.find((r) => r.error)
+  if (failed?.error) return { error: failed.error.message }
+
+  revalidateTag("experience", "max")
+  return { success: true }
+}

--- a/src/app/admin/experience/experience-form.tsx
+++ b/src/app/admin/experience/experience-form.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import { useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { useForm, useWatch } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { toast } from "sonner"
+import { experienceSchema, type ExperienceFormValues } from "@/lib/schemas/experience"
+import { createExperience, updateExperience } from "./actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Switch } from "@/components/ui/switch"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormDescription,
+} from "@/components/ui/form"
+import { FormSection } from "@/components/admin/form-section"
+import { DynamicList } from "@/components/admin/dynamic-list"
+import { ImageUpload } from "@/components/admin/image-upload"
+import type { Experience } from "@/types/database"
+
+interface ExperienceFormProps {
+  data?: Experience
+}
+
+export function ExperienceForm({ data }: ExperienceFormProps) {
+  const [isPending, startTransition] = useTransition()
+  const router = useRouter()
+  const isEdit = !!data
+
+  const form = useForm<ExperienceFormValues>({
+    resolver: zodResolver(experienceSchema),
+    defaultValues: {
+      company: data?.company ?? "",
+      role: data?.role ?? "",
+      location: data?.location ?? "",
+      start_date: data?.start_date ?? "",
+      end_date: data?.end_date ?? "",
+      description: data?.description ?? "",
+      achievements: data?.achievements ?? [],
+      company_logo_url: data?.company_logo_url ?? "",
+      company_url: data?.company_url ?? "",
+      published: data?.published ?? true,
+      show_on_resume: data?.show_on_resume ?? true,
+    },
+  })
+
+  const endDate = useWatch({ control: form.control, name: "end_date" })
+  const isPresent = !endDate
+
+  function onSubmit(values: ExperienceFormValues) {
+    startTransition(async () => {
+      const result = isEdit
+        ? await updateExperience(data.id, values)
+        : await createExperience(values)
+
+      if (result?.error) {
+        toast.error(result.error)
+      } else {
+        toast.success(isEdit ? "Experience updated" : "Experience created")
+        if (!isEdit) router.push("/admin/experience")
+      }
+    })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormSection title="Company Info">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="company"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Company</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Role</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="location"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Location</FormLabel>
+                  <FormControl><Input placeholder="Remote / San Francisco, CA" {...field} value={field.value ?? ""} /></FormControl>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="company_url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Company URL</FormLabel>
+                  <FormControl><Input type="url" placeholder="https://..." {...field} value={field.value ?? ""} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <FormField
+            control={form.control}
+            name="company_logo_url"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Company Logo</FormLabel>
+                <FormControl>
+                  <ImageUpload
+                    value={field.value || null}
+                    onChange={(url) => field.onChange(url ?? "")}
+                    bucket="projects"
+                    path="logos"
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <FormSection title="Dates">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="start_date"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Start Date</FormLabel>
+                  <FormControl><Input type="date" {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="end_date"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>End Date</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="date"
+                      disabled={isPresent}
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="present"
+              checked={isPresent}
+              onCheckedChange={(checked) => {
+                form.setValue("end_date", checked ? null : "")
+              }}
+            />
+            <label htmlFor="present" className="text-sm">Currently working here</label>
+          </div>
+        </FormSection>
+
+        <FormSection title="Details">
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description</FormLabel>
+                <FormControl><Textarea rows={4} {...field} value={field.value ?? ""} /></FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="achievements"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Achievements</FormLabel>
+                <FormControl>
+                  <DynamicList items={field.value ?? []} onChange={field.onChange} placeholder="Add achievement..." />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <FormSection title="Visibility">
+          <div className="flex flex-col gap-4">
+            <FormField
+              control={form.control}
+              name="published"
+              render={({ field }) => (
+                <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                  <div>
+                    <FormLabel>Published</FormLabel>
+                    <FormDescription>Show on the public site</FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch checked={field.value} onCheckedChange={field.onChange} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="show_on_resume"
+              render={({ field }) => (
+                <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                  <div>
+                    <FormLabel>Show on Resume</FormLabel>
+                    <FormDescription>Include in the generated resume</FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch checked={field.value} onCheckedChange={field.onChange} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </div>
+        </FormSection>
+
+        <div className="flex gap-3">
+          <Button type="submit" disabled={isPending}>
+            {isPending ? "Saving..." : isEdit ? "Save Changes" : "Create Experience"}
+          </Button>
+          <Button type="button" variant="outline" onClick={() => router.push("/admin/experience")}>
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </Form>
+  )
+}

--- a/src/app/admin/experience/experience-list.tsx
+++ b/src/app/admin/experience/experience-list.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import Link from "next/link"
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core"
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { GripVertical, Pencil, Trash2, Plus } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { deleteExperience, updateExperienceOrder } from "./actions"
+import type { Experience } from "@/types/database"
+
+function SortableRow({ exp }: { exp: Experience }) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: exp.id })
+  const [showDelete, setShowDelete] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  const dateRange = `${exp.start_date}${exp.end_date ? ` — ${exp.end_date}` : " — Present"}`
+
+  function handleDelete() {
+    startTransition(async () => {
+      const result = await deleteExperience(exp.id)
+      if (result?.error) toast.error(result.error)
+      else toast.success("Experience deleted")
+      setShowDelete(false)
+    })
+  }
+
+  return (
+    <>
+      <div ref={setNodeRef} style={style} className="flex items-center gap-3 rounded-lg border p-3">
+        <button type="button" className="cursor-grab text-muted-foreground" {...attributes} {...listeners}>
+          <GripVertical className="h-4 w-4" />
+        </button>
+        <div className="flex-1 min-w-0">
+          <p className="font-medium truncate">{exp.role}</p>
+          <p className="text-sm text-muted-foreground truncate">{exp.company} &middot; {dateRange}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant={exp.published ? "default" : "outline"}>
+            {exp.published ? "Published" : "Draft"}
+          </Badge>
+          <Link href={`/admin/experience/${exp.id}`}>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <Pencil className="h-4 w-4" />
+            </Button>
+          </Link>
+          <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-destructive" onClick={() => setShowDelete(true)}>
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      <Dialog open={showDelete} onOpenChange={setShowDelete}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete this experience entry?</DialogTitle>
+            <DialogDescription>{exp.role} at {exp.company}. This action cannot be undone.</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowDelete(false)}>Cancel</Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={isPending}>
+              {isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+export function ExperienceList({ entries: initial }: { entries: Experience[] }) {
+  const [entries, setEntries] = useState(initial)
+  const [, startTransition] = useTransition()
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (over && active.id !== over.id) {
+      const oldIndex = entries.findIndex((e) => e.id === active.id)
+      const newIndex = entries.findIndex((e) => e.id === over.id)
+      const reordered = arrayMove(entries, oldIndex, newIndex)
+      setEntries(reordered)
+      startTransition(async () => {
+        const result = await updateExperienceOrder(reordered.map((e) => e.id))
+        if (result?.error) toast.error(result.error)
+      })
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">{entries.length} entries</p>
+        <Link href="/admin/experience/new">
+          <Button size="sm">
+            <Plus className="mr-2 h-4 w-4" />
+            New Experience
+          </Button>
+        </Link>
+      </div>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={entries.map((e) => e.id)} strategy={verticalListSortingStrategy}>
+          <div className="space-y-2">
+            {entries.map((exp) => (
+              <SortableRow key={exp.id} exp={exp} />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+      {entries.length === 0 && (
+        <p className="text-center text-muted-foreground py-8">No experience entries yet.</p>
+      )}
+    </div>
+  )
+}

--- a/src/app/admin/experience/new/page.tsx
+++ b/src/app/admin/experience/new/page.tsx
@@ -1,0 +1,13 @@
+import { AdminHeader } from "../../admin-header"
+import { ExperienceForm } from "../experience-form"
+
+export default function NewExperiencePage() {
+  return (
+    <>
+      <AdminHeader title="New Experience" />
+      <div className="p-4 md:p-6 max-w-3xl">
+        <ExperienceForm />
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/experience/page.tsx
+++ b/src/app/admin/experience/page.tsx
@@ -1,0 +1,21 @@
+import { createClient } from "@/lib/supabase/server"
+import { AdminHeader } from "../admin-header"
+import { ExperienceList } from "./experience-list"
+import type { Experience } from "@/types/database"
+
+export default async function ExperiencePage() {
+  const supabase = await createClient()
+  const { data } = await supabase
+    .from("experience")
+    .select("*")
+    .order("sort_order", { ascending: true })
+
+  return (
+    <>
+      <AdminHeader title="Experience" />
+      <div className="p-4 md:p-6 max-w-4xl">
+        <ExperienceList entries={(data as Experience[]) ?? []} />
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/hero/actions.ts
+++ b/src/app/admin/hero/actions.ts
@@ -1,0 +1,22 @@
+"use server"
+
+import { revalidateTag, revalidatePath } from "next/cache"
+import { createClient } from "@/lib/supabase/server"
+import { requireAuth } from "@/lib/admin-auth"
+import { heroSchema, type HeroFormValues } from "@/lib/schemas/hero"
+
+export async function updateHero(data: HeroFormValues) {
+  await requireAuth()
+  const validated = heroSchema.parse(data)
+  const supabase = await createClient()
+
+  const { data: current } = await supabase.from("hero_section").select("id").single()
+  if (!current) return { error: "Hero section not found" }
+
+  const { error } = await supabase.from("hero_section").update(validated).eq("id", current.id)
+  if (error) return { error: error.message }
+
+  revalidateTag("hero", "max")
+  revalidatePath("/")
+  return { success: true }
+}

--- a/src/app/admin/hero/hero-form.tsx
+++ b/src/app/admin/hero/hero-form.tsx
@@ -1,0 +1,196 @@
+"use client"
+
+import { useTransition } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { toast } from "sonner"
+import { heroSchema, type HeroFormValues } from "@/lib/schemas/hero"
+import { updateHero } from "./actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { FormSection } from "@/components/admin/form-section"
+import { DynamicList } from "@/components/admin/dynamic-list"
+import { ImageUpload } from "@/components/admin/image-upload"
+import type { HeroSection } from "@/types/database"
+
+interface HeroFormProps {
+  data: HeroSection
+}
+
+export function HeroForm({ data }: HeroFormProps) {
+  const [isPending, startTransition] = useTransition()
+
+  const form = useForm<HeroFormValues>({
+    resolver: zodResolver(heroSchema),
+    defaultValues: {
+      greeting: data.greeting ?? "",
+      name: data.name,
+      rotating_titles: data.rotating_titles,
+      description: data.description ?? "",
+      cta_primary_text: data.cta_primary_text ?? "",
+      cta_primary_link: data.cta_primary_link ?? "",
+      cta_secondary_text: data.cta_secondary_text ?? "",
+      cta_secondary_link: data.cta_secondary_link ?? "",
+      avatar_url: data.avatar_url ?? "",
+      resume_url: data.resume_url ?? "",
+    },
+  })
+
+  function onSubmit(values: HeroFormValues) {
+    startTransition(async () => {
+      const result = await updateHero(values)
+      if (result?.error) {
+        toast.error(result.error)
+      } else {
+        toast.success("Hero section updated")
+      }
+    })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormSection title="Identity">
+          <FormField
+            control={form.control}
+            name="greeting"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Greeting</FormLabel>
+                <FormControl><Input placeholder="Hi, I'm" {...field} value={field.value ?? ""} /></FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormControl><Input {...field} /></FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="rotating_titles"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Rotating Titles</FormLabel>
+                <FormControl>
+                  <DynamicList
+                    items={field.value}
+                    onChange={field.onChange}
+                    placeholder="Add a title..."
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description</FormLabel>
+                <FormControl><Textarea rows={4} {...field} value={field.value ?? ""} /></FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <FormSection title="Call-to-Action Buttons">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="cta_primary_text"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Primary Button Text</FormLabel>
+                  <FormControl><Input {...field} value={field.value ?? ""} /></FormControl>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="cta_primary_link"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Primary Button Link</FormLabel>
+                  <FormControl><Input placeholder="#projects" {...field} value={field.value ?? ""} /></FormControl>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="cta_secondary_text"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Secondary Button Text</FormLabel>
+                  <FormControl><Input {...field} value={field.value ?? ""} /></FormControl>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="cta_secondary_link"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Secondary Button Link</FormLabel>
+                  <FormControl><Input placeholder="#contact" {...field} value={field.value ?? ""} /></FormControl>
+                </FormItem>
+              )}
+            />
+          </div>
+        </FormSection>
+
+        <FormSection title="Media">
+          <FormField
+            control={form.control}
+            name="avatar_url"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Avatar</FormLabel>
+                <FormControl>
+                  <ImageUpload
+                    value={field.value || null}
+                    onChange={(url) => field.onChange(url ?? "")}
+                    bucket="avatars"
+                    path="hero"
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="resume_url"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Resume URL</FormLabel>
+                <FormControl><Input placeholder="https://..." {...field} value={field.value ?? ""} /></FormControl>
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "Saving..." : "Save Changes"}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/src/app/admin/hero/page.tsx
+++ b/src/app/admin/hero/page.tsx
@@ -1,0 +1,29 @@
+import { createClient } from "@/lib/supabase/server"
+import { AdminHeader } from "../admin-header"
+import { HeroForm } from "./hero-form"
+import type { HeroSection } from "@/types/database"
+
+export default async function HeroPage() {
+  const supabase = await createClient()
+  const { data } = await supabase.from("hero_section").select("*").single()
+
+  if (!data) {
+    return (
+      <>
+        <AdminHeader title="Hero" />
+        <div className="p-4 md:p-6">
+          <p className="text-muted-foreground">No hero section found. Run the seed script first.</p>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <AdminHeader title="Hero" />
+      <div className="p-4 md:p-6 max-w-3xl">
+        <HeroForm data={data as HeroSection} />
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,36 @@
+import { requireAuth } from "@/lib/admin-auth"
+import { createClient } from "@/lib/supabase/server"
+import { AdminSidebar } from "./admin-sidebar"
+import { Toaster } from "@/components/ui/sonner"
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  await requireAuth()
+
+  // Fetch unread message count for sidebar badge
+  const supabase = await createClient()
+  const { count } = await supabase
+    .from("contact_submissions")
+    .select("*", { count: "exact", head: true })
+    .eq("read", false)
+
+  return (
+    <div className="min-h-screen bg-background" data-theme="light">
+      <div className="flex">
+        {/* Desktop sidebar */}
+        <aside className="hidden md:flex md:w-64 md:flex-col md:fixed md:inset-y-0 border-r bg-background">
+          <AdminSidebar unreadCount={count ?? 0} />
+        </aside>
+
+        {/* Main content */}
+        <main className="flex-1 md:pl-64">
+          {children}
+        </main>
+      </div>
+      <Toaster />
+    </div>
+  )
+}

--- a/src/app/admin/messages/actions.ts
+++ b/src/app/admin/messages/actions.ts
@@ -1,0 +1,37 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { createClient } from "@/lib/supabase/server"
+import { requireAuth } from "@/lib/admin-auth"
+
+export async function markMessageRead(id: string, read: boolean) {
+  await requireAuth()
+  const supabase = await createClient()
+
+  const { error } = await supabase
+    .from("contact_submissions")
+    .update({ read })
+    .eq("id", id)
+
+  if (error) return { error: error.message }
+
+  revalidatePath("/admin/messages")
+  revalidatePath("/admin")
+  return { success: true }
+}
+
+export async function deleteMessage(id: string) {
+  await requireAuth()
+  const supabase = await createClient()
+
+  const { error } = await supabase
+    .from("contact_submissions")
+    .delete()
+    .eq("id", id)
+
+  if (error) return { error: error.message }
+
+  revalidatePath("/admin/messages")
+  revalidatePath("/admin")
+  return { success: true }
+}

--- a/src/app/admin/messages/messages-list.tsx
+++ b/src/app/admin/messages/messages-list.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { Mail, MailOpen, Trash2 } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { markMessageRead, deleteMessage } from "./actions"
+import type { ContactSubmission } from "@/types/database"
+
+export function MessagesList({ messages }: { messages: ContactSubmission[] }) {
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<ContactSubmission | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function handleToggleRead(msg: ContactSubmission) {
+    startTransition(async () => {
+      const result = await markMessageRead(msg.id, !msg.read)
+      if (result?.error) toast.error(result.error)
+    })
+  }
+
+  function handleDelete() {
+    if (!deleteTarget) return
+    startTransition(async () => {
+      const result = await deleteMessage(deleteTarget.id)
+      if (result?.error) toast.error(result.error)
+      else toast.success("Message deleted")
+      setDeleteTarget(null)
+    })
+  }
+
+  function handleExpand(msg: ContactSubmission) {
+    setExpandedId(expandedId === msg.id ? null : msg.id)
+    // Auto-mark as read when expanding
+    if (!msg.read) {
+      startTransition(async () => {
+        await markMessageRead(msg.id, true)
+      })
+    }
+  }
+
+  const unread = messages.filter((m) => !m.read)
+  const read = messages.filter((m) => m.read)
+
+  function renderMessage(msg: ContactSubmission) {
+    const isExpanded = expandedId === msg.id
+    return (
+      <div key={msg.id} className="rounded-lg border overflow-hidden">
+        <button
+          type="button"
+          onClick={() => handleExpand(msg)}
+          className="w-full flex items-center gap-3 p-3 text-left hover:bg-accent/50 transition-colors"
+        >
+          {!msg.read && <span className="h-2 w-2 rounded-full bg-blue-500 flex-shrink-0" />}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <span className={`font-medium truncate ${!msg.read ? "text-foreground" : "text-muted-foreground"}`}>
+                {msg.name}
+              </span>
+              <span className="text-xs text-muted-foreground">&lt;{msg.email}&gt;</span>
+            </div>
+            <p className="text-sm text-muted-foreground truncate">{msg.subject || "(No subject)"}</p>
+          </div>
+          <span className="text-xs text-muted-foreground whitespace-nowrap">
+            {new Date(msg.created_at).toLocaleDateString()}
+          </span>
+        </button>
+        {isExpanded && (
+          <div className="border-t p-4 space-y-3 bg-muted/50">
+            <div className="text-sm whitespace-pre-wrap">{msg.message}</div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handleToggleRead(msg)}
+                disabled={isPending}
+              >
+                {msg.read ? (
+                  <><Mail className="mr-2 h-3 w-3" /> Mark Unread</>
+                ) : (
+                  <><MailOpen className="mr-2 h-3 w-3" /> Mark Read</>
+                )}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="text-destructive hover:text-destructive"
+                onClick={() => setDeleteTarget(msg)}
+              >
+                <Trash2 className="mr-2 h-3 w-3" /> Delete
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <Tabs defaultValue="all">
+        <TabsList className="mb-4">
+          <TabsTrigger value="all">
+            All ({messages.length})
+          </TabsTrigger>
+          <TabsTrigger value="unread">
+            Unread
+            {unread.length > 0 && (
+              <Badge variant="destructive" className="ml-2 h-5 min-w-5 px-1 text-xs">
+                {unread.length}
+              </Badge>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="read">Read ({read.length})</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="all" className="space-y-2">
+          {messages.length === 0 && <p className="text-center text-muted-foreground py-8">No messages yet</p>}
+          {messages.map(renderMessage)}
+        </TabsContent>
+        <TabsContent value="unread" className="space-y-2">
+          {unread.length === 0 && <p className="text-center text-muted-foreground py-8">All caught up!</p>}
+          {unread.map(renderMessage)}
+        </TabsContent>
+        <TabsContent value="read" className="space-y-2">
+          {read.length === 0 && <p className="text-center text-muted-foreground py-8">No read messages</p>}
+          {read.map(renderMessage)}
+        </TabsContent>
+      </Tabs>
+
+      <Dialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete this message?</DialogTitle>
+            <DialogDescription>From: {deleteTarget?.name}. This action cannot be undone.</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>Cancel</Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={isPending}>
+              {isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/app/admin/messages/page.tsx
+++ b/src/app/admin/messages/page.tsx
@@ -1,0 +1,21 @@
+import { createClient } from "@/lib/supabase/server"
+import { AdminHeader } from "../admin-header"
+import { MessagesList } from "./messages-list"
+import type { ContactSubmission } from "@/types/database"
+
+export default async function MessagesPage() {
+  const supabase = await createClient()
+  const { data } = await supabase
+    .from("contact_submissions")
+    .select("*")
+    .order("created_at", { ascending: false })
+
+  return (
+    <>
+      <AdminHeader title="Messages" />
+      <div className="p-4 md:p-6 max-w-4xl">
+        <MessagesList messages={(data as ContactSubmission[]) ?? []} />
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,36 @@
+import { createClient } from "@/lib/supabase/server"
+import { AdminHeader } from "./admin-header"
+import { DashboardCards } from "./dashboard-cards"
+import type { ContactSubmission } from "@/types/database"
+
+export default async function AdminDashboardPage() {
+  const supabase = await createClient()
+
+  // Fetch counts in parallel
+  const [projects, skills, experience, blogPosts, unread, recent] = await Promise.all([
+    supabase.from("projects").select("*", { count: "exact", head: true }),
+    supabase.from("skills").select("*", { count: "exact", head: true }),
+    supabase.from("experience").select("*", { count: "exact", head: true }),
+    supabase.from("blog_posts").select("*", { count: "exact", head: true }),
+    supabase.from("contact_submissions").select("*", { count: "exact", head: true }).eq("read", false),
+    supabase.from("contact_submissions").select("*").order("created_at", { ascending: false }).limit(5),
+  ])
+
+  return (
+    <>
+      <AdminHeader title="Dashboard" />
+      <div className="p-4 md:p-6">
+        <DashboardCards
+          counts={{
+            projects: projects.count ?? 0,
+            skills: skills.count ?? 0,
+            experience: experience.count ?? 0,
+            blog_posts: blogPosts.count ?? 0,
+            unread_messages: unread.count ?? 0,
+          }}
+          recentMessages={(recent.data as ContactSubmission[]) ?? []}
+        />
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/projects/[id]/page.tsx
+++ b/src/app/admin/projects/[id]/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
+import { AdminHeader } from "../../admin-header"
+import { ProjectForm } from "../project-form"
+import type { Project } from "@/types/database"
+
+export default async function EditProjectPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createClient()
+  const { data } = await supabase.from("projects").select("*").eq("id", id).single()
+
+  if (!data) notFound()
+
+  return (
+    <>
+      <AdminHeader title={`Edit: ${data.title}`} />
+      <div className="p-4 md:p-6 max-w-3xl">
+        <ProjectForm data={data as Project} />
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/projects/actions.ts
+++ b/src/app/admin/projects/actions.ts
@@ -1,0 +1,71 @@
+"use server"
+
+import { revalidateTag, revalidatePath } from "next/cache"
+import { createClient } from "@/lib/supabase/server"
+import { requireAuth } from "@/lib/admin-auth"
+import { projectSchema, type ProjectFormValues } from "@/lib/schemas/project"
+
+export async function createProject(data: ProjectFormValues) {
+  await requireAuth()
+  const validated = projectSchema.parse(data)
+  const supabase = await createClient()
+
+  // Auto-increment sort_order
+  const { data: last } = await supabase
+    .from("projects")
+    .select("sort_order")
+    .order("sort_order", { ascending: false })
+    .limit(1)
+    .single()
+
+  const sort_order = (last?.sort_order ?? 0) + 1
+
+  const { error } = await supabase.from("projects").insert({ ...validated, sort_order })
+  if (error) return { error: error.message }
+
+  revalidateTag("projects", "max")
+  revalidatePath("/")
+  return { success: true }
+}
+
+export async function updateProject(id: string, data: ProjectFormValues) {
+  await requireAuth()
+  const validated = projectSchema.parse(data)
+  const supabase = await createClient()
+
+  const { error } = await supabase.from("projects").update(validated).eq("id", id)
+  if (error) return { error: error.message }
+
+  revalidateTag("projects", "max")
+  revalidatePath("/")
+  return { success: true }
+}
+
+export async function deleteProject(id: string) {
+  await requireAuth()
+  const supabase = await createClient()
+
+  const { error } = await supabase.from("projects").delete().eq("id", id)
+  if (error) return { error: error.message }
+
+  revalidateTag("projects", "max")
+  revalidatePath("/")
+  return { success: true }
+}
+
+export async function updateProjectOrder(ids: string[]) {
+  await requireAuth()
+  const supabase = await createClient()
+
+  // Update sort_order for each project based on array position
+  const updates = ids.map((id, index) =>
+    supabase.from("projects").update({ sort_order: index }).eq("id", id)
+  )
+
+  const results = await Promise.all(updates)
+  const failed = results.find((r) => r.error)
+  if (failed?.error) return { error: failed.error.message }
+
+  revalidateTag("projects", "max")
+  return { success: true }
+}

--- a/src/app/admin/projects/new/page.tsx
+++ b/src/app/admin/projects/new/page.tsx
@@ -1,0 +1,13 @@
+import { AdminHeader } from "../../admin-header"
+import { ProjectForm } from "../project-form"
+
+export default function NewProjectPage() {
+  return (
+    <>
+      <AdminHeader title="New Project" />
+      <div className="p-4 md:p-6 max-w-3xl">
+        <ProjectForm />
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/projects/page.tsx
+++ b/src/app/admin/projects/page.tsx
@@ -1,0 +1,21 @@
+import { createClient } from "@/lib/supabase/server"
+import { AdminHeader } from "../admin-header"
+import { ProjectsList } from "./projects-list"
+import type { Project } from "@/types/database"
+
+export default async function ProjectsPage() {
+  const supabase = await createClient()
+  const { data } = await supabase
+    .from("projects")
+    .select("*")
+    .order("sort_order", { ascending: true })
+
+  return (
+    <>
+      <AdminHeader title="Projects" />
+      <div className="p-4 md:p-6 max-w-4xl">
+        <ProjectsList projects={(data as Project[]) ?? []} />
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/projects/project-form.tsx
+++ b/src/app/admin/projects/project-form.tsx
@@ -1,0 +1,266 @@
+"use client"
+
+import { useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { useForm, useWatch } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { toast } from "sonner"
+import { projectSchema, type ProjectFormValues } from "@/lib/schemas/project"
+import { createProject, updateProject } from "./actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Switch } from "@/components/ui/switch"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormDescription,
+} from "@/components/ui/form"
+import { FormSection } from "@/components/admin/form-section"
+import { DynamicList } from "@/components/admin/dynamic-list"
+import { ImageUpload } from "@/components/admin/image-upload"
+import type { Project } from "@/types/database"
+
+interface ProjectFormProps {
+  data?: Project
+}
+
+function slugify(text: string) {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+export function ProjectForm({ data }: ProjectFormProps) {
+  const [isPending, startTransition] = useTransition()
+  const router = useRouter()
+  const isEdit = !!data
+
+  const form = useForm<ProjectFormValues>({
+    resolver: zodResolver(projectSchema),
+    defaultValues: {
+      title: data?.title ?? "",
+      slug: data?.slug ?? "",
+      short_description: data?.short_description ?? "",
+      long_description: data?.long_description ?? "",
+      thumbnail_url: data?.thumbnail_url ?? "",
+      images: data?.images ?? [],
+      tech_stack: data?.tech_stack ?? [],
+      color: data?.color ?? "",
+      year: data?.year ?? "",
+      live_url: data?.live_url ?? "",
+      github_url: data?.github_url ?? "",
+      featured: data?.featured ?? false,
+      published: data?.published ?? true,
+    },
+  })
+
+  function onSubmit(values: ProjectFormValues) {
+    startTransition(async () => {
+      const result = isEdit
+        ? await updateProject(data.id, values)
+        : await createProject(values)
+
+      if (result?.error) {
+        toast.error(result.error)
+      } else {
+        toast.success(isEdit ? "Project updated" : "Project created")
+        if (!isEdit) router.push("/admin/projects")
+      }
+    })
+  }
+
+  // Auto-generate slug from title
+  function handleTitleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    form.setValue("title", e.target.value)
+    if (!isEdit || !data?.slug) {
+      form.setValue("slug", slugify(e.target.value))
+    }
+  }
+
+  const shortDescValue = useWatch({ control: form.control, name: "short_description" }) ?? ""
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormSection title="Basic Info">
+          <FormField
+            control={form.control}
+            name="title"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Title</FormLabel>
+                <FormControl>
+                  <Input {...field} onChange={handleTitleChange} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="slug"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Slug</FormLabel>
+                <FormControl><Input {...field} /></FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="short_description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Short Description ({shortDescValue.length}/160)</FormLabel>
+                <FormControl><Textarea rows={2} {...field} /></FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="long_description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Long Description</FormLabel>
+                <FormControl><Textarea rows={6} {...field} value={field.value ?? ""} /></FormControl>
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <FormSection title="Media">
+          <FormField
+            control={form.control}
+            name="thumbnail_url"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Thumbnail</FormLabel>
+                <FormControl>
+                  <ImageUpload
+                    value={field.value || null}
+                    onChange={(url) => field.onChange(url ?? "")}
+                    bucket="projects"
+                    path="thumbnails"
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <FormSection title="Details">
+          <FormField
+            control={form.control}
+            name="tech_stack"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Tech Stack</FormLabel>
+                <FormControl>
+                  <DynamicList items={field.value ?? []} onChange={field.onChange} placeholder="Add technology..." />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="color"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Accent Color</FormLabel>
+                  <FormControl><Input placeholder="#6366f1" {...field} value={field.value ?? ""} /></FormControl>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="year"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Year</FormLabel>
+                  <FormControl><Input placeholder="2026" {...field} value={field.value ?? ""} /></FormControl>
+                </FormItem>
+              )}
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="live_url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Live URL</FormLabel>
+                  <FormControl><Input type="url" placeholder="https://..." {...field} value={field.value ?? ""} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="github_url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>GitHub URL</FormLabel>
+                  <FormControl><Input type="url" placeholder="https://github.com/..." {...field} value={field.value ?? ""} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </FormSection>
+
+        <FormSection title="Visibility">
+          <div className="flex flex-col gap-4">
+            <FormField
+              control={form.control}
+              name="featured"
+              render={({ field }) => (
+                <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                  <div>
+                    <FormLabel>Featured</FormLabel>
+                    <FormDescription>Highlight this project on the home page</FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch checked={field.value} onCheckedChange={field.onChange} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="published"
+              render={({ field }) => (
+                <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                  <div>
+                    <FormLabel>Published</FormLabel>
+                    <FormDescription>Make this project visible to the public</FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch checked={field.value} onCheckedChange={field.onChange} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </div>
+        </FormSection>
+
+        <div className="flex gap-3">
+          <Button type="submit" disabled={isPending}>
+            {isPending ? "Saving..." : isEdit ? "Save Changes" : "Create Project"}
+          </Button>
+          <Button type="button" variant="outline" onClick={() => router.push("/admin/projects")}>
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </Form>
+  )
+}

--- a/src/app/admin/projects/projects-list.tsx
+++ b/src/app/admin/projects/projects-list.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import Link from "next/link"
+import Image from "next/image"
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core"
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { GripVertical, Pencil, Trash2, Plus } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { deleteProject, updateProjectOrder } from "./actions"
+import type { Project } from "@/types/database"
+
+function SortableRow({ project }: { project: Project }) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: project.id })
+  const [showDelete, setShowDelete] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  function handleDelete() {
+    startTransition(async () => {
+      const result = await deleteProject(project.id)
+      if (result?.error) toast.error(result.error)
+      else toast.success("Project deleted")
+      setShowDelete(false)
+    })
+  }
+
+  return (
+    <>
+      <div ref={setNodeRef} style={style} className="flex items-center gap-3 rounded-lg border p-3">
+        <button type="button" className="cursor-grab text-muted-foreground" {...attributes} {...listeners}>
+          <GripVertical className="h-4 w-4" />
+        </button>
+        {project.thumbnail_url && (
+          <Image
+            src={project.thumbnail_url}
+            alt={project.title}
+            width={48}
+            height={48}
+            className="rounded object-cover"
+            unoptimized
+          />
+        )}
+        <div className="flex-1 min-w-0">
+          <p className="font-medium truncate">{project.title}</p>
+          <p className="text-xs text-muted-foreground truncate">{project.short_description}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          {project.featured && <Badge variant="secondary">Featured</Badge>}
+          <Badge variant={project.published ? "default" : "outline"}>
+            {project.published ? "Published" : "Draft"}
+          </Badge>
+          <Link href={`/admin/projects/${project.id}`}>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <Pencil className="h-4 w-4" />
+            </Button>
+          </Link>
+          <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-destructive" onClick={() => setShowDelete(true)}>
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      <Dialog open={showDelete} onOpenChange={setShowDelete}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete &quot;{project.title}&quot;?</DialogTitle>
+            <DialogDescription>This action cannot be undone.</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowDelete(false)}>Cancel</Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={isPending}>
+              {isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+export function ProjectsList({ projects: initial }: { projects: Project[] }) {
+  const [projects, setProjects] = useState(initial)
+  const [, startTransition] = useTransition()
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (over && active.id !== over.id) {
+      const oldIndex = projects.findIndex((p) => p.id === active.id)
+      const newIndex = projects.findIndex((p) => p.id === over.id)
+      const reordered = arrayMove(projects, oldIndex, newIndex)
+      setProjects(reordered)
+      startTransition(async () => {
+        const result = await updateProjectOrder(reordered.map((p) => p.id))
+        if (result?.error) toast.error(result.error)
+      })
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">{projects.length} projects</p>
+        <Link href="/admin/projects/new">
+          <Button size="sm">
+            <Plus className="mr-2 h-4 w-4" />
+            New Project
+          </Button>
+        </Link>
+      </div>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={projects.map((p) => p.id)} strategy={verticalListSortingStrategy}>
+          <div className="space-y-2">
+            {projects.map((project) => (
+              <SortableRow key={project.id} project={project} />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+      {projects.length === 0 && (
+        <p className="text-center text-muted-foreground py-8">No projects yet. Create your first one!</p>
+      )}
+    </div>
+  )
+}

--- a/src/app/admin/resume/page.tsx
+++ b/src/app/admin/resume/page.tsx
@@ -1,0 +1,20 @@
+import { AdminHeader } from "../admin-header"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { FileDown } from "lucide-react"
+
+export default function ResumeAdminPage() {
+  return (
+    <>
+      <AdminHeader title="Resume" />
+      <div className="p-4 md:p-6 max-w-3xl">
+        <Alert>
+          <FileDown className="h-4 w-4" />
+          <AlertTitle>Coming Soon</AlertTitle>
+          <AlertDescription>
+            Resume builder will be implemented in Issue #4.
+          </AlertDescription>
+        </Alert>
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/settings/actions.ts
+++ b/src/app/admin/settings/actions.ts
@@ -1,0 +1,22 @@
+"use server"
+
+import { revalidateTag, revalidatePath } from "next/cache"
+import { createClient } from "@/lib/supabase/server"
+import { requireAuth } from "@/lib/admin-auth"
+import { settingsSchema, type SettingsFormValues } from "@/lib/schemas/settings"
+
+export async function updateSettings(data: SettingsFormValues) {
+  await requireAuth()
+  const validated = settingsSchema.parse(data)
+  const supabase = await createClient()
+
+  const { data: current } = await supabase.from("site_settings").select("id").single()
+  if (!current) return { error: "Site settings not found" }
+
+  const { error } = await supabase.from("site_settings").update(validated).eq("id", current.id)
+  if (error) return { error: error.message }
+
+  revalidateTag("site_settings", "max")
+  revalidatePath("/")
+  return { success: true }
+}

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,0 +1,29 @@
+import { createClient } from "@/lib/supabase/server"
+import { AdminHeader } from "../admin-header"
+import { SettingsForm } from "./settings-form"
+import type { SiteSettings } from "@/types/database"
+
+export default async function SettingsPage() {
+  const supabase = await createClient()
+  const { data } = await supabase.from("site_settings").select("*").single()
+
+  if (!data) {
+    return (
+      <>
+        <AdminHeader title="Settings" />
+        <div className="p-4 md:p-6">
+          <p className="text-muted-foreground">No site settings found. Run the seed script first.</p>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <AdminHeader title="Settings" />
+      <div className="p-4 md:p-6 max-w-3xl">
+        <SettingsForm data={data as SiteSettings} />
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/settings/settings-form.tsx
+++ b/src/app/admin/settings/settings-form.tsx
@@ -1,0 +1,133 @@
+"use client"
+
+import { useTransition } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { toast } from "sonner"
+import { settingsSchema, type SettingsFormValues } from "@/lib/schemas/settings"
+import { updateSettings } from "./actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Switch } from "@/components/ui/switch"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormDescription,
+} from "@/components/ui/form"
+import { FormSection } from "@/components/admin/form-section"
+import { ImageUpload } from "@/components/admin/image-upload"
+import type { SiteSettings } from "@/types/database"
+
+interface SettingsFormProps {
+  data: SiteSettings
+}
+
+export function SettingsForm({ data }: SettingsFormProps) {
+  const [isPending, startTransition] = useTransition()
+
+  const form = useForm<SettingsFormValues>({
+    resolver: zodResolver(settingsSchema),
+    defaultValues: {
+      site_title: data.site_title,
+      site_description: data.site_description ?? "",
+      og_image_url: data.og_image_url ?? "",
+      google_analytics_id: data.google_analytics_id ?? "",
+      maintenance_mode: data.maintenance_mode,
+    },
+  })
+
+  function onSubmit(values: SettingsFormValues) {
+    startTransition(async () => {
+      const result = await updateSettings(values)
+      if (result?.error) {
+        toast.error(result.error)
+      } else {
+        toast.success("Settings updated")
+      }
+    })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormSection title="Site Metadata">
+          <FormField
+            control={form.control}
+            name="site_title"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Site Title</FormLabel>
+                <FormControl><Input {...field} /></FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="site_description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Site Description</FormLabel>
+                <FormControl><Textarea rows={3} {...field} value={field.value ?? ""} /></FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="og_image_url"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>OG Image</FormLabel>
+                <FormControl>
+                  <ImageUpload
+                    value={field.value || null}
+                    onChange={(url) => field.onChange(url ?? "")}
+                    bucket="avatars"
+                    path="og"
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <FormSection title="Analytics & Advanced">
+          <FormField
+            control={form.control}
+            name="google_analytics_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Google Analytics ID</FormLabel>
+                <FormControl><Input placeholder="G-XXXXXXXXXX" {...field} value={field.value ?? ""} /></FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="maintenance_mode"
+            render={({ field }) => (
+              <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                <div>
+                  <FormLabel>Maintenance Mode</FormLabel>
+                  <FormDescription>Temporarily disable the public site</FormDescription>
+                </div>
+                <FormControl>
+                  <Switch checked={field.value} onCheckedChange={field.onChange} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "Saving..." : "Save Changes"}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/src/app/admin/skills/actions.ts
+++ b/src/app/admin/skills/actions.ts
@@ -1,0 +1,70 @@
+"use server"
+
+import { revalidateTag, revalidatePath } from "next/cache"
+import { createClient } from "@/lib/supabase/server"
+import { requireAuth } from "@/lib/admin-auth"
+import { skillSchema, type SkillFormValues } from "@/lib/schemas/skill"
+
+export async function createSkill(data: SkillFormValues) {
+  await requireAuth()
+  const validated = skillSchema.parse(data)
+  const supabase = await createClient()
+
+  const { data: last } = await supabase
+    .from("skills")
+    .select("sort_order")
+    .eq("category", validated.category)
+    .order("sort_order", { ascending: false })
+    .limit(1)
+    .single()
+
+  const sort_order = (last?.sort_order ?? 0) + 1
+
+  const { error } = await supabase.from("skills").insert({ ...validated, sort_order })
+  if (error) return { error: error.message }
+
+  revalidateTag("skills", "max")
+  revalidatePath("/")
+  return { success: true }
+}
+
+export async function updateSkill(id: string, data: SkillFormValues) {
+  await requireAuth()
+  const validated = skillSchema.parse(data)
+  const supabase = await createClient()
+
+  const { error } = await supabase.from("skills").update(validated).eq("id", id)
+  if (error) return { error: error.message }
+
+  revalidateTag("skills", "max")
+  revalidatePath("/")
+  return { success: true }
+}
+
+export async function deleteSkill(id: string) {
+  await requireAuth()
+  const supabase = await createClient()
+
+  const { error } = await supabase.from("skills").delete().eq("id", id)
+  if (error) return { error: error.message }
+
+  revalidateTag("skills", "max")
+  revalidatePath("/")
+  return { success: true }
+}
+
+export async function updateSkillOrder(ids: string[]) {
+  await requireAuth()
+  const supabase = await createClient()
+
+  const updates = ids.map((id, index) =>
+    supabase.from("skills").update({ sort_order: index }).eq("id", id)
+  )
+
+  const results = await Promise.all(updates)
+  const failed = results.find((r) => r.error)
+  if (failed?.error) return { error: failed.error.message }
+
+  revalidateTag("skills", "max")
+  return { success: true }
+}

--- a/src/app/admin/skills/page.tsx
+++ b/src/app/admin/skills/page.tsx
@@ -1,0 +1,21 @@
+import { createClient } from "@/lib/supabase/server"
+import { AdminHeader } from "../admin-header"
+import { SkillsList } from "./skills-list"
+import type { Skill } from "@/types/database"
+
+export default async function SkillsPage() {
+  const supabase = await createClient()
+  const { data } = await supabase
+    .from("skills")
+    .select("*")
+    .order("sort_order", { ascending: true })
+
+  return (
+    <>
+      <AdminHeader title="Skills" />
+      <div className="p-4 md:p-6 max-w-4xl">
+        <SkillsList skills={(data as Skill[]) ?? []} />
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/skills/skill-form.tsx
+++ b/src/app/admin/skills/skill-form.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import { useTransition } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { toast } from "sonner"
+import { skillSchema, type SkillFormValues } from "@/lib/schemas/skill"
+import { createSkill, updateSkill } from "./actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Switch } from "@/components/ui/switch"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import type { Skill } from "@/types/database"
+
+const CATEGORIES = ["Frontend", "Backend", "DevOps", "Database", "Tools"]
+
+interface SkillFormDialogProps {
+  data?: Skill
+  onDone: () => void
+}
+
+export function SkillFormDialog({ data, onDone }: SkillFormDialogProps) {
+  const [isPending, startTransition] = useTransition()
+  const isEdit = !!data
+
+  const form = useForm<SkillFormValues>({
+    resolver: zodResolver(skillSchema),
+    defaultValues: {
+      name: data?.name ?? "",
+      category: data?.category ?? "Frontend",
+      icon_name: data?.icon_name ?? "",
+      icon_url: data?.icon_url ?? "",
+      published: data?.published ?? true,
+      show_on_resume: data?.show_on_resume ?? true,
+    },
+  })
+
+  function onSubmit(values: SkillFormValues) {
+    startTransition(async () => {
+      const result = isEdit
+        ? await updateSkill(data.id, values)
+        : await createSkill(values)
+
+      if (result?.error) {
+        toast.error(result.error)
+      } else {
+        toast.success(isEdit ? "Skill updated" : "Skill created")
+        onDone()
+      }
+    })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Name</FormLabel>
+              <FormControl><Input {...field} /></FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="category"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Category</FormLabel>
+              <Select onValueChange={field.onChange} defaultValue={field.value}>
+                <FormControl>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {CATEGORIES.map((cat) => (
+                    <SelectItem key={cat} value={cat}>{cat}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="icon_name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Icon Name</FormLabel>
+              <FormControl><Input placeholder="e.g. SiReact" {...field} value={field.value ?? ""} /></FormControl>
+            </FormItem>
+          )}
+        />
+        <div className="flex items-center gap-6">
+          <FormField
+            control={form.control}
+            name="published"
+            render={({ field }) => (
+              <FormItem className="flex items-center gap-2">
+                <FormControl>
+                  <Switch checked={field.value} onCheckedChange={field.onChange} />
+                </FormControl>
+                <FormLabel className="!mt-0">Published</FormLabel>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="show_on_resume"
+            render={({ field }) => (
+              <FormItem className="flex items-center gap-2">
+                <FormControl>
+                  <Switch checked={field.value} onCheckedChange={field.onChange} />
+                </FormControl>
+                <FormLabel className="!mt-0">Show on Resume</FormLabel>
+              </FormItem>
+            )}
+          />
+        </div>
+        <div className="flex gap-3 pt-2">
+          <Button type="submit" disabled={isPending}>
+            {isPending ? "Saving..." : isEdit ? "Save" : "Create"}
+          </Button>
+          <Button type="button" variant="outline" onClick={onDone}>Cancel</Button>
+        </div>
+      </form>
+    </Form>
+  )
+}

--- a/src/app/admin/skills/skills-list.tsx
+++ b/src/app/admin/skills/skills-list.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { Pencil, Trash2, Plus } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { SkillFormDialog } from "./skill-form"
+import { deleteSkill } from "./actions"
+import type { Skill } from "@/types/database"
+
+const CATEGORIES = ["Frontend", "Backend", "DevOps", "Database", "Tools"]
+
+export function SkillsList({ skills }: { skills: Skill[] }) {
+  const [editingSkill, setEditingSkill] = useState<Skill | null>(null)
+  const [showCreate, setShowCreate] = useState(false)
+  const [createCategory, setCreateCategory] = useState("Frontend")
+  const [deleteTarget, setDeleteTarget] = useState<Skill | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function handleDelete() {
+    if (!deleteTarget) return
+    startTransition(async () => {
+      const result = await deleteSkill(deleteTarget.id)
+      if (result?.error) toast.error(result.error)
+      else toast.success("Skill deleted")
+      setDeleteTarget(null)
+    })
+  }
+
+  const grouped = CATEGORIES.reduce((acc, cat) => {
+    acc[cat] = skills.filter((s) => s.category === cat).sort((a, b) => a.sort_order - b.sort_order)
+    return acc
+  }, {} as Record<string, Skill[]>)
+
+  return (
+    <>
+      <Tabs defaultValue="Frontend">
+        <div className="flex items-center justify-between mb-4">
+          <TabsList>
+            {CATEGORIES.map((cat) => (
+              <TabsTrigger key={cat} value={cat}>
+                {cat} ({grouped[cat]?.length ?? 0})
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </div>
+        {CATEGORIES.map((cat) => (
+          <TabsContent key={cat} value={cat} className="space-y-2">
+            {grouped[cat]?.map((skill) => (
+              <div key={skill.id} className="flex items-center justify-between rounded-lg border p-3">
+                <div className="flex items-center gap-3">
+                  <span className="font-medium">{skill.name}</span>
+                  {skill.icon_name && (
+                    <span className="text-xs text-muted-foreground">{skill.icon_name}</span>
+                  )}
+                  <Badge variant={skill.published ? "default" : "outline"}>
+                    {skill.published ? "Published" : "Draft"}
+                  </Badge>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => setEditingSkill(skill)}>
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-destructive" onClick={() => setDeleteTarget(skill)}>
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full"
+              onClick={() => { setCreateCategory(cat); setShowCreate(true) }}
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              Add {cat} Skill
+            </Button>
+          </TabsContent>
+        ))}
+      </Tabs>
+
+      {/* Edit Dialog */}
+      <Dialog open={!!editingSkill} onOpenChange={(open) => !open && setEditingSkill(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Skill</DialogTitle>
+          </DialogHeader>
+          {editingSkill && (
+            <SkillFormDialog data={editingSkill} onDone={() => setEditingSkill(null)} />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Create Dialog */}
+      <Dialog open={showCreate} onOpenChange={setShowCreate}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New Skill</DialogTitle>
+          </DialogHeader>
+          <SkillFormDialog
+            data={{ category: createCategory } as Skill}
+            onDone={() => setShowCreate(false)}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation */}
+      <Dialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete &quot;{deleteTarget?.name}&quot;?</DialogTitle>
+            <DialogDescription>This action cannot be undone.</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>Cancel</Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={isPending}>
+              {isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { contactSchema } from "@/lib/schemas/contact"
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+    const validated = contactSchema.parse(body)
+
+    // Use admin client to bypass RLS (public insert policy exists, but admin is more reliable)
+    const supabase = createAdminClient()
+
+    const { error } = await supabase
+      .from("contact_submissions")
+      .insert(validated)
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true }, { status: 201 })
+  } catch (err) {
+    if (err instanceof Error && err.name === "ZodError") {
+      return NextResponse.json({ error: "Invalid form data" }, { status: 400 })
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -232,6 +232,28 @@
   }
 }
 
+/* ─── Login page floating orbs ─── */
+@keyframes login-float-1 {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33% { transform: translate(30px, -20px) scale(1.05); }
+  66% { transform: translate(-15px, 15px) scale(0.97); }
+}
+
+@keyframes login-float-2 {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33% { transform: translate(-25px, 20px) scale(0.95); }
+  66% { transform: translate(20px, -10px) scale(1.03); }
+}
+
+@keyframes login-float-3 {
+  0%, 100% { transform: translate(-50%, -50%) scale(1); }
+  50% { transform: translate(-50%, -50%) scale(1.15); }
+}
+
+.login-orb-1 { animation: login-float-1 12s ease-in-out infinite; }
+.login-orb-2 { animation: login-float-2 15s ease-in-out infinite; }
+.login-orb-3 { animation: login-float-3 10s ease-in-out infinite; }
+
 /* ─── Scroll indicator animation ─── */
 @keyframes scroll-line {
   0% {

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -1,0 +1,33 @@
+"use server"
+
+import { redirect } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
+
+export async function login(formData: { email: string; password: string }) {
+  const supabase = await createClient()
+
+  const { error } = await supabase.auth.signInWithPassword({
+    email: formData.email,
+    password: formData.password,
+  })
+
+  if (error) {
+    return { error: error.message }
+  }
+
+  redirect("/admin")
+}
+
+export async function resetPassword(email: string) {
+  const supabase = await createClient()
+
+  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+    redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/api/auth/callback?next=/admin`,
+  })
+
+  if (error) {
+    return { error: error.message }
+  }
+
+  return { success: true }
+}

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { toast } from "sonner"
+import { Eye, EyeOff, Loader2, ArrowRight } from "lucide-react"
+import { login, resetPassword } from "./actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+
+const loginSchema = z.object({
+  email: z.string().email("Please enter a valid email"),
+  password: z.string().min(1, "Password is required"),
+})
+
+type LoginValues = z.input<typeof loginSchema>
+
+export function LoginForm() {
+  const [isPending, startTransition] = useTransition()
+  const [showPassword, setShowPassword] = useState(false)
+  const [showReset, setShowReset] = useState(false)
+
+  const form = useForm<LoginValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { email: "", password: "" },
+  })
+
+  function onSubmit(values: LoginValues) {
+    startTransition(async () => {
+      const result = await login(values)
+      if (result?.error) {
+        toast.error(result.error)
+      }
+    })
+  }
+
+  function onResetPassword() {
+    const email = form.getValues("email")
+    if (!email) {
+      toast.error("Enter your email first")
+      return
+    }
+    startTransition(async () => {
+      const result = await resetPassword(email)
+      if (result?.error) {
+        toast.error(result.error)
+      } else {
+        toast.success("Check your email for a reset link")
+        setShowReset(false)
+      }
+    })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Email
+              </FormLabel>
+              <FormControl>
+                <Input
+                  type="email"
+                  placeholder="you@example.com"
+                  autoComplete="email"
+                  className="h-11 rounded-xl border-border/50 bg-background/50 px-4 text-sm backdrop-blur-sm transition-all focus-visible:border-primary/50 focus-visible:bg-background/80"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <div className="flex items-center justify-between">
+                <FormLabel className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Password
+                </FormLabel>
+                {!showReset && (
+                  <button
+                    type="button"
+                    onClick={() => setShowReset(true)}
+                    className="text-xs text-muted-foreground/70 transition-colors hover:text-primary"
+                  >
+                    Forgot?
+                  </button>
+                )}
+              </div>
+              <FormControl>
+                <div className="relative">
+                  <Input
+                    type={showPassword ? "text" : "password"}
+                    placeholder="Enter your password"
+                    autoComplete="current-password"
+                    className="h-11 rounded-xl border-border/50 bg-background/50 px-4 pr-11 text-sm backdrop-blur-sm transition-all focus-visible:border-primary/50 focus-visible:bg-background/80"
+                    {...field}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground/50 transition-colors hover:text-muted-foreground"
+                    tabIndex={-1}
+                  >
+                    {showPassword ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </button>
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Reset password inline */}
+        {showReset && (
+          <div className="rounded-xl border border-primary/10 bg-primary/5 p-3">
+            <p className="mb-2 text-xs text-muted-foreground">
+              We&apos;ll send a reset link to the email above.
+            </p>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={onResetPassword}
+                disabled={isPending}
+                className="h-8 rounded-lg text-xs"
+              >
+                {isPending ? (
+                  <><Loader2 className="mr-1 h-3 w-3 animate-spin" /> Sending...</>
+                ) : (
+                  "Send Reset Link"
+                )}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => setShowReset(false)}
+                className="h-8 rounded-lg text-xs text-muted-foreground"
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <Button
+          type="submit"
+          disabled={isPending}
+          className="h-11 w-full rounded-xl text-sm font-medium tracking-wide transition-all"
+        >
+          {isPending ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Signing in...
+            </>
+          ) : (
+            <>
+              Continue
+              <ArrowRight className="h-4 w-4" />
+            </>
+          )}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link"
+import { ArrowLeft } from "lucide-react"
+import { LoginForm } from "./login-form"
+
+export default function LoginPage() {
+  return (
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background p-4">
+      {/* Gradient mesh background — matches Hero */}
+      <div className="gradient-mesh absolute inset-0 -z-10" />
+
+      {/* Animated floating orbs */}
+      <div className="absolute inset-0 -z-[5] overflow-hidden" aria-hidden="true">
+        <div className="login-orb-1 absolute top-[15%] left-[10%] h-72 w-72 rounded-full opacity-20 blur-3xl"
+          style={{ background: "oklch(0.7 0.25 264 / 40%)" }}
+        />
+        <div className="login-orb-2 absolute right-[10%] bottom-[15%] h-96 w-96 rounded-full opacity-15 blur-3xl"
+          style={{ background: "oklch(0.7 0.2 330 / 30%)" }}
+        />
+        <div className="login-orb-3 absolute top-[50%] left-[50%] h-64 w-64 -translate-x-1/2 -translate-y-1/2 rounded-full opacity-10 blur-3xl"
+          style={{ background: "oklch(0.65 0.2 160 / 25%)" }}
+        />
+      </div>
+
+      {/* Subtle grid */}
+      <div className="absolute inset-0 -z-10 opacity-[0.02]">
+        <div
+          className="h-full w-full"
+          style={{
+            backgroundImage: `
+              linear-gradient(var(--foreground) 1px, transparent 1px),
+              linear-gradient(90deg, var(--foreground) 1px, transparent 1px)
+            `,
+            backgroundSize: "60px 60px",
+          }}
+        />
+      </div>
+
+      {/* Noise overlay */}
+      <div className="noise-overlay pointer-events-none" />
+
+      {/* Back to site */}
+      <Link
+        href="/"
+        className="absolute top-6 left-6 z-10 flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to site
+      </Link>
+
+      {/* Login card */}
+      <div className="relative w-full max-w-[400px]">
+        {/* Glow behind card */}
+        <div
+          className="absolute -inset-px -z-10 rounded-2xl opacity-60 blur-xl"
+          style={{ background: "linear-gradient(135deg, oklch(0.7 0.25 264 / 20%), oklch(0.7 0.2 330 / 15%))" }}
+          aria-hidden="true"
+        />
+
+        <div className="glass rounded-2xl p-8 sm:p-10">
+          {/* Header */}
+          <div className="mb-8 text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10 ring-1 ring-primary/20">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="22"
+                height="22"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-primary"
+              >
+                <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+                <polyline points="10 17 15 12 10 7" />
+                <line x1="15" y1="12" x2="3" y2="12" />
+              </svg>
+            </div>
+            <h1 className="text-[length:var(--text-xl)] font-semibold tracking-tight">
+              Welcome back
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Sign in to your portfolio dashboard
+            </p>
+          </div>
+
+          <LoginForm />
+
+          {/* Footer */}
+          <p className="mt-8 text-center text-xs text-muted-foreground/60">
+            Protected area. Authorized access only.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,9 +19,10 @@ import {
   getBlogData,
   getNavLinks,
 } from "@/lib/queries";
+import { createClient } from "@/lib/supabase/server";
 
 export default async function Home() {
-  const [siteConfig, heroData, aboutData, projectsData, skillsData, experienceData, blogData, navLinks] =
+  const [siteConfig, heroData, aboutData, projectsData, skillsData, experienceData, blogData, navLinks, supabase] =
     await Promise.all([
       getSiteConfig(),
       getHeroData(),
@@ -31,13 +32,16 @@ export default async function Home() {
       getExperienceData(),
       getBlogData(),
       getNavLinks(),
+      createClient(),
     ]);
+
+  const { data: { user } } = await supabase.auth.getUser();
 
   return (
     <div className="noise-overlay relative">
       <CustomCursor />
       <ScrollProgress />
-      <Navigation navLinks={navLinks} siteConfig={siteConfig} />
+      <Navigation navLinks={navLinks} siteConfig={siteConfig} isAuthenticated={!!user} />
       <main>
         <Hero heroData={heroData} siteConfig={siteConfig} />
         <About aboutData={aboutData} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useTransition } from "react";
+import Link from "next/link";
 import { motion, AnimatePresence } from "motion/react";
+import { LogIn, LayoutDashboard, LogOut } from "lucide-react";
 import { ThemeToggle } from "./ThemeToggle";
 import { cn } from "@/lib/utils";
+import { logout } from "@/app/admin/actions";
 
 interface NavigationProps {
   navLinks: { label: string; href: string }[];
+  isAuthenticated?: boolean;
   siteConfig: {
     name: string;
     title: string;
@@ -30,11 +34,12 @@ const defaultSiteConfig: NonNullable<NavigationProps["siteConfig"]> = {
   socials: {},
 };
 
-export function Navigation({ navLinks, siteConfig: siteConfigProp }: NavigationProps) {
+export function Navigation({ navLinks, siteConfig: siteConfigProp, isAuthenticated = false }: NavigationProps) {
   const siteConfig = siteConfigProp ?? defaultSiteConfig;
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const [activeSection, setActiveSection] = useState("");
+  const [isLoggingOut, startLogoutTransition] = useTransition();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -63,7 +68,7 @@ export function Navigation({ navLinks, siteConfig: siteConfigProp }: NavigationP
       window.removeEventListener("scroll", handleScroll);
       observer.disconnect();
     };
-  }, []);
+  }, [navLinks]);
 
   return (
     <>
@@ -118,6 +123,37 @@ export function Navigation({ navLinks, siteConfig: siteConfigProp }: NavigationP
           </div>
 
           <div className="flex items-center gap-3">
+            {/* Auth buttons — desktop */}
+            <div className="hidden items-center gap-2 md:flex">
+              {isAuthenticated ? (
+                <>
+                  <Link
+                    href="/admin"
+                    className="flex items-center gap-1.5 rounded-full border border-border/50 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/30 hover:text-foreground"
+                  >
+                    <LayoutDashboard className="h-3 w-3" />
+                    Dashboard
+                  </Link>
+                  <button
+                    onClick={() => startLogoutTransition(() => logout())}
+                    disabled={isLoggingOut}
+                    className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    <LogOut className="h-3 w-3" />
+                    {isLoggingOut ? "..." : "Logout"}
+                  </button>
+                </>
+              ) : (
+                <Link
+                  href="/login"
+                  className="flex items-center gap-1.5 rounded-full border border-border/50 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/30 hover:text-foreground"
+                >
+                  <LogIn className="h-3 w-3" />
+                  Sign In
+                </Link>
+              )}
+            </div>
+
             <ThemeToggle />
 
             {/* Mobile menu button */}
@@ -180,6 +216,45 @@ export function Navigation({ navLinks, siteConfig: siteConfigProp }: NavigationP
                   {link.label}
                 </motion.a>
               ))}
+
+              {/* Auth link — mobile */}
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 10 }}
+                transition={{ delay: navLinks.length * 0.07, duration: 0.4 }}
+                className="mt-4 flex items-center gap-4 border-t border-border/30 pt-8"
+              >
+                {isAuthenticated ? (
+                  <>
+                    <Link
+                      href="/admin"
+                      onClick={() => setIsMobileOpen(false)}
+                      className="flex items-center gap-2 text-lg font-medium text-muted-foreground transition-colors hover:text-primary"
+                    >
+                      <LayoutDashboard className="h-5 w-5" />
+                      Dashboard
+                    </Link>
+                    <button
+                      onClick={() => { setIsMobileOpen(false); startLogoutTransition(() => logout()) }}
+                      disabled={isLoggingOut}
+                      className="flex items-center gap-2 text-lg font-medium text-muted-foreground transition-colors hover:text-primary"
+                    >
+                      <LogOut className="h-5 w-5" />
+                      Logout
+                    </button>
+                  </>
+                ) : (
+                  <Link
+                    href="/login"
+                    onClick={() => setIsMobileOpen(false)}
+                    className="flex items-center gap-2 text-lg font-medium text-muted-foreground transition-colors hover:text-primary"
+                  >
+                    <LogIn className="h-5 w-5" />
+                    Sign In
+                  </Link>
+                )}
+              </motion.div>
             </nav>
           </motion.div>
         )}

--- a/src/components/admin/dynamic-key-value-list.tsx
+++ b/src/components/admin/dynamic-key-value-list.tsx
@@ -1,0 +1,170 @@
+"use client"
+
+import { useState } from "react"
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core"
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { GripVertical, Plus, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+interface KeyValueItem {
+  label: string
+  value: string
+}
+
+interface DynamicKeyValueListProps {
+  items: KeyValueItem[]
+  onChange: (items: KeyValueItem[]) => void
+  keyLabel?: string
+  valueLabel?: string
+}
+
+function SortableRow({
+  id,
+  item,
+  keyLabel,
+  valueLabel,
+  onRemove,
+  onEdit,
+}: {
+  id: string
+  item: KeyValueItem
+  keyLabel: string
+  valueLabel: string
+  onRemove: () => void
+  onEdit: (item: KeyValueItem) => void
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <div ref={setNodeRef} style={style} className="flex items-center gap-2">
+      <button type="button" className="cursor-grab text-muted-foreground" {...attributes} {...listeners}>
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <Input
+        value={item.label}
+        onChange={(e) => onEdit({ ...item, label: e.target.value })}
+        placeholder={keyLabel}
+        className="flex-1"
+      />
+      <Input
+        value={item.value}
+        onChange={(e) => onEdit({ ...item, value: e.target.value })}
+        placeholder={valueLabel}
+        className="flex-1"
+      />
+      <Button type="button" variant="ghost" size="icon" onClick={onRemove} className="h-8 w-8 text-muted-foreground hover:text-destructive">
+        <Trash2 className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}
+
+export function DynamicKeyValueList({
+  items,
+  onChange,
+  keyLabel = "Label",
+  valueLabel = "Value",
+}: DynamicKeyValueListProps) {
+  const [newKey, setNewKey] = useState("")
+  const [newValue, setNewValue] = useState("")
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  const itemIds = items.map((_, i) => `kv-${i}`)
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (over && active.id !== over.id) {
+      const oldIndex = itemIds.indexOf(active.id as string)
+      const newIndex = itemIds.indexOf(over.id as string)
+      onChange(arrayMove(items, oldIndex, newIndex))
+    }
+  }
+
+  function addItem() {
+    if (!newKey.trim() || !newValue.trim()) return
+    onChange([...items, { label: newKey.trim(), value: newValue.trim() }])
+    setNewKey("")
+    setNewValue("")
+  }
+
+  function removeItem(index: number) {
+    onChange(items.filter((_, i) => i !== index))
+  }
+
+  function editItem(index: number, item: KeyValueItem) {
+    const updated = [...items]
+    updated[index] = item
+    onChange(updated)
+  }
+
+  return (
+    <div className="space-y-2">
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+          <div className="space-y-2">
+            {items.map((item, i) => (
+              <SortableRow
+                key={itemIds[i]}
+                id={itemIds[i]}
+                item={item}
+                keyLabel={keyLabel}
+                valueLabel={valueLabel}
+                onRemove={() => removeItem(i)}
+                onEdit={(v) => editItem(i, v)}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+      <div className="flex items-center gap-2">
+        <Input
+          value={newKey}
+          onChange={(e) => setNewKey(e.target.value)}
+          placeholder={keyLabel}
+          className="flex-1"
+        />
+        <Input
+          value={newValue}
+          onChange={(e) => setNewValue(e.target.value)}
+          placeholder={valueLabel}
+          className="flex-1"
+          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addItem() } }}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          onClick={addItem}
+          disabled={!newKey.trim() || !newValue.trim()}
+          className="h-9 w-9"
+        >
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/dynamic-list.tsx
+++ b/src/components/admin/dynamic-list.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+import { useState } from "react"
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core"
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { GripVertical, Plus, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+interface DynamicListProps {
+  items: string[]
+  onChange: (items: string[]) => void
+  label?: string
+  placeholder?: string
+  maxItems?: number
+}
+
+function SortableItem({
+  id,
+  value,
+  onRemove,
+  onEdit,
+}: {
+  id: string
+  value: string
+  onRemove: () => void
+  onEdit: (value: string) => void
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <div ref={setNodeRef} style={style} className="flex items-center gap-2">
+      <button type="button" className="cursor-grab text-muted-foreground" {...attributes} {...listeners}>
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <Input
+        value={value}
+        onChange={(e) => onEdit(e.target.value)}
+        className="flex-1"
+      />
+      <Button type="button" variant="ghost" size="icon" onClick={onRemove} className="h-8 w-8 text-muted-foreground hover:text-destructive">
+        <Trash2 className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}
+
+export function DynamicList({ items, onChange, label, placeholder, maxItems }: DynamicListProps) {
+  const [newValue, setNewValue] = useState("")
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  // Stable IDs for each item
+  const itemIds = items.map((_, i) => `item-${i}`)
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (over && active.id !== over.id) {
+      const oldIndex = itemIds.indexOf(active.id as string)
+      const newIndex = itemIds.indexOf(over.id as string)
+      onChange(arrayMove(items, oldIndex, newIndex))
+    }
+  }
+
+  function addItem() {
+    const trimmed = newValue.trim()
+    if (!trimmed) return
+    if (maxItems && items.length >= maxItems) return
+    onChange([...items, trimmed])
+    setNewValue("")
+  }
+
+  function removeItem(index: number) {
+    onChange(items.filter((_, i) => i !== index))
+  }
+
+  function editItem(index: number, value: string) {
+    const updated = [...items]
+    updated[index] = value
+    onChange(updated)
+  }
+
+  return (
+    <div className="space-y-2">
+      {label && <p className="text-sm font-medium">{label}</p>}
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+          <div className="space-y-2">
+            {items.map((item, i) => (
+              <SortableItem
+                key={itemIds[i]}
+                id={itemIds[i]}
+                value={item}
+                onRemove={() => removeItem(i)}
+                onEdit={(v) => editItem(i, v)}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+      <div className="flex items-center gap-2">
+        <Input
+          value={newValue}
+          onChange={(e) => setNewValue(e.target.value)}
+          placeholder={placeholder ?? "Add item..."}
+          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addItem() } }}
+          className="flex-1"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          onClick={addItem}
+          disabled={!newValue.trim() || (maxItems != null && items.length >= maxItems)}
+          className="h-9 w-9"
+        >
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/form-section.tsx
+++ b/src/components/admin/form-section.tsx
@@ -1,0 +1,21 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+interface FormSectionProps {
+  title: string
+  description?: string
+  children: React.ReactNode
+}
+
+export function FormSection({ title, description, children }: FormSectionProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">{title}</CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {children}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/admin/image-upload.tsx
+++ b/src/components/admin/image-upload.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import { useState, useRef } from "react"
+import Image from "next/image"
+import { Upload, X, Loader2 } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { createClient } from "@/lib/supabase/client"
+
+interface ImageUploadProps {
+  value: string | null
+  onChange: (url: string | null) => void
+  bucket: "avatars" | "projects" | "blog" | "resume"
+  path?: string
+}
+
+const MAX_SIZE = 5 * 1024 * 1024 // 5MB
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"]
+
+export function ImageUpload({ value, onChange, bucket, path = "" }: ImageUploadProps) {
+  const [uploading, setUploading] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  async function handleUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      toast.error("Only JPEG, PNG, WebP, and GIF are allowed")
+      return
+    }
+    if (file.size > MAX_SIZE) {
+      toast.error("File must be under 5MB")
+      return
+    }
+
+    setUploading(true)
+    try {
+      const supabase = createClient()
+      const ext = file.name.split(".").pop()
+      const filename = `${path ? path + "/" : ""}${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`
+
+      const { error } = await supabase.storage
+        .from(bucket)
+        .upload(filename, file, { upsert: true })
+
+      if (error) throw error
+
+      const { data: { publicUrl } } = supabase.storage
+        .from(bucket)
+        .getPublicUrl(filename)
+
+      onChange(publicUrl)
+      toast.success("Image uploaded")
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Upload failed")
+    } finally {
+      setUploading(false)
+      if (inputRef.current) inputRef.current.value = ""
+    }
+  }
+
+  function handleRemove() {
+    onChange(null)
+  }
+
+  return (
+    <div className="space-y-2">
+      {value ? (
+        <div className="relative inline-block">
+          <Image
+            src={value}
+            alt="Upload preview"
+            width={200}
+            height={200}
+            className="rounded-md border object-cover"
+            unoptimized
+          />
+          <Button
+            type="button"
+            variant="destructive"
+            size="icon"
+            className="absolute -top-2 -right-2 h-6 w-6"
+            onClick={handleRemove}
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          disabled={uploading}
+          className="flex h-32 w-full items-center justify-center rounded-md border-2 border-dashed border-muted-foreground/25 hover:border-muted-foreground/50 transition-colors"
+        >
+          {uploading ? (
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          ) : (
+            <div className="flex flex-col items-center gap-1 text-muted-foreground">
+              <Upload className="h-6 w-6" />
+              <span className="text-xs">Click to upload</span>
+            </div>
+          )}
+        </button>
+      )}
+      <input
+        ref={inputRef}
+        type="file"
+        accept={ALLOWED_TYPES.join(",")}
+        onChange={handleUpload}
+        className="hidden"
+      />
+    </div>
+  )
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import * as React from "react"
+import { Avatar as AvatarPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root> & {
+  size?: "default" | "sm" | "lg"
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 overflow-hidden rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full", className)}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "bg-muted text-muted-foreground flex size-full items-center justify-center rounded-full text-sm group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "bg-primary text-primary-foreground ring-background absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full ring-2 select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "*:data-[slot=avatar]:ring-background group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "bg-muted text-muted-foreground ring-background relative flex size-8 shrink-0 items-center justify-center rounded-full text-sm ring-2 group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarBadge,
+  AvatarGroup,
+  AvatarGroupCount,
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon } from "lucide-react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import * as React from "react"
+import type { Label as LabelPrimitive } from "radix-ui"
+import { Slot } from "radix-ui"
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  useFormState,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState } = useFormContext()
+  const formState = useFormState({ name: fieldContext.name })
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+function FormItem({ className, ...props }: React.ComponentProps<"div">) {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        data-slot="form-item"
+        className={cn("grid gap-2", className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  )
+}
+
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      data-slot="form-label"
+      data-error={!!error}
+      className={cn("data-[error=true]:text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+}
+
+function FormControl({ ...props }: React.ComponentProps<typeof Slot.Root>) {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot.Root
+      data-slot="form-control"
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+}
+
+function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message ?? "") : props.children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      data-slot="form-message"
+      id={formMessageId}
+      className={cn("text-destructive text-sm", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+}
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import * as React from "react"
+import { ScrollArea as ScrollAreaPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          side === "right" &&
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+          side === "left" &&
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+          side === "top" &&
+            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+          side === "bottom" &&
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block rounded-full ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 data-[state=active]:text-foreground",
+        "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -1,0 +1,13 @@
+import { redirect } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
+
+export async function requireAuth() {
+  const supabase = await createClient()
+  const { data: { user }, error } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    redirect("/login")
+  }
+
+  return user
+}

--- a/src/lib/schemas/about.ts
+++ b/src/lib/schemas/about.ts
@@ -1,0 +1,16 @@
+import { z } from "zod"
+
+export const aboutSchema = z.object({
+  heading: z.string().nullable().default(null),
+  subheading: z.string().nullable().default(null),
+  bio: z.string().min(1, "Bio is required"),
+  bio_secondary: z.string().nullable().default(null),
+  portrait_url: z.string().nullable().default(null),
+  stats: z.array(z.object({
+    label: z.string().min(1),
+    value: z.string().min(1),
+  })).default([]),
+  tech_stack: z.array(z.string().min(1)).default([]),
+})
+
+export type AboutFormValues = z.input<typeof aboutSchema>

--- a/src/lib/schemas/contact.ts
+++ b/src/lib/schemas/contact.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const contactSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  email: z.string().email("Invalid email address"),
+  subject: z.string().nullable().default(null),
+  message: z.string().min(10, "Message must be at least 10 characters"),
+})
+
+export type ContactFormValues = z.input<typeof contactSchema>

--- a/src/lib/schemas/experience.ts
+++ b/src/lib/schemas/experience.ts
@@ -1,0 +1,17 @@
+import { z } from "zod"
+
+export const experienceSchema = z.object({
+  company: z.string().min(1, "Company is required"),
+  role: z.string().min(1, "Role is required"),
+  location: z.string().nullable().default(null),
+  start_date: z.string().min(1, "Start date is required"),
+  end_date: z.string().nullable().default(null),
+  description: z.string().nullable().default(null),
+  achievements: z.array(z.string().min(1)).default([]),
+  company_logo_url: z.string().nullable().default(null),
+  company_url: z.string().url("Must be a valid URL").nullable().or(z.literal("")).transform(v => v || null),
+  published: z.boolean().default(true),
+  show_on_resume: z.boolean().default(true),
+})
+
+export type ExperienceFormValues = z.input<typeof experienceSchema>

--- a/src/lib/schemas/hero.ts
+++ b/src/lib/schemas/hero.ts
@@ -1,0 +1,16 @@
+import { z } from "zod"
+
+export const heroSchema = z.object({
+  greeting: z.string().nullable().default(null),
+  name: z.string().min(1, "Name is required"),
+  rotating_titles: z.array(z.string().min(1)).min(1, "At least one title is required"),
+  description: z.string().nullable().default(null),
+  cta_primary_text: z.string().nullable().default(null),
+  cta_primary_link: z.string().nullable().default(null),
+  cta_secondary_text: z.string().nullable().default(null),
+  cta_secondary_link: z.string().nullable().default(null),
+  avatar_url: z.string().nullable().default(null),
+  resume_url: z.string().nullable().default(null),
+})
+
+export type HeroFormValues = z.input<typeof heroSchema>

--- a/src/lib/schemas/project.ts
+++ b/src/lib/schemas/project.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const projectSchema = z.object({
+  title: z.string().min(1, "Title is required"),
+  slug: z.string().min(1, "Slug is required").regex(/^[a-z0-9-]+$/, "Slug must be lowercase with hyphens"),
+  short_description: z.string().min(1, "Short description is required").max(160, "Max 160 characters"),
+  long_description: z.string().nullable().default(null),
+  thumbnail_url: z.string().nullable().default(null),
+  images: z.array(z.string()).default([]),
+  tech_stack: z.array(z.string().min(1)).default([]),
+  color: z.string().nullable().default(null),
+  year: z.string().nullable().default(null),
+  live_url: z.string().url("Must be a valid URL").nullable().or(z.literal("")).transform(v => v || null),
+  github_url: z.string().url("Must be a valid URL").nullable().or(z.literal("")).transform(v => v || null),
+  featured: z.boolean().default(false),
+  published: z.boolean().default(true),
+})
+
+export type ProjectFormValues = z.input<typeof projectSchema>

--- a/src/lib/schemas/settings.ts
+++ b/src/lib/schemas/settings.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const settingsSchema = z.object({
+  site_title: z.string().min(1, "Site title is required"),
+  site_description: z.string().nullable().default(null),
+  og_image_url: z.string().nullable().default(null),
+  google_analytics_id: z.string().nullable().default(null),
+  maintenance_mode: z.boolean().default(false),
+})
+
+export type SettingsFormValues = z.input<typeof settingsSchema>

--- a/src/lib/schemas/skill.ts
+++ b/src/lib/schemas/skill.ts
@@ -1,0 +1,12 @@
+import { z } from "zod"
+
+export const skillSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  category: z.string().min(1, "Category is required"),
+  icon_name: z.string().nullable().default(null),
+  icon_url: z.string().nullable().default(null),
+  published: z.boolean().default(true),
+  show_on_resume: z.boolean().default(true),
+})
+
+export type SkillFormValues = z.input<typeof skillSchema>

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,0 +1,139 @@
+// TypeScript interfaces matching the Supabase database schema exactly
+
+export interface SiteSettings {
+  id: string
+  site_title: string
+  site_description: string | null
+  og_image_url: string | null
+  favicon_url: string | null
+  google_analytics_id: string | null
+  social_links: Record<string, string>
+  contact_email: string | null
+  contact_form_enabled: boolean
+  maintenance_mode: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface HeroSection {
+  id: string
+  greeting: string | null
+  name: string
+  rotating_titles: string[]
+  description: string | null
+  cta_primary_text: string | null
+  cta_primary_link: string | null
+  cta_secondary_text: string | null
+  cta_secondary_link: string | null
+  avatar_url: string | null
+  resume_url: string | null
+  updated_at: string
+}
+
+export interface AboutSection {
+  id: string
+  heading: string | null
+  subheading: string | null
+  bio: string
+  bio_secondary: string | null
+  portrait_url: string | null
+  stats: { label: string; value: string }[]
+  tech_stack: string[]
+  updated_at: string
+}
+
+export interface Project {
+  id: string
+  title: string
+  slug: string
+  short_description: string
+  long_description: string | null
+  thumbnail_url: string | null
+  images: string[]
+  tech_stack: string[]
+  color: string | null
+  year: string | null
+  live_url: string | null
+  github_url: string | null
+  featured: boolean
+  sort_order: number
+  published: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface Skill {
+  id: string
+  name: string
+  category: string
+  icon_name: string | null
+  icon_url: string | null
+  sort_order: number
+  published: boolean
+  show_on_resume: boolean
+  created_at: string
+}
+
+export interface Experience {
+  id: string
+  company: string
+  role: string
+  location: string | null
+  start_date: string
+  end_date: string | null
+  description: string | null
+  achievements: string[]
+  company_logo_url: string | null
+  company_url: string | null
+  sort_order: number
+  published: boolean
+  show_on_resume: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface BlogPost {
+  id: string
+  title: string
+  slug: string
+  excerpt: string | null
+  content: string
+  cover_image_url: string | null
+  tags: string[]
+  published: boolean
+  published_at: string | null
+  read_time_minutes: number | null
+  meta_title: string | null
+  meta_description: string | null
+  og_image_url: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface Resume {
+  id: string
+  full_name: string
+  title: string
+  email: string | null
+  phone: string | null
+  location: string | null
+  website: string | null
+  linkedin: string | null
+  github: string | null
+  summary: string | null
+  education: Record<string, unknown>[]
+  certifications: Record<string, unknown>[]
+  additional_sections: Record<string, unknown>[]
+  pdf_url: string | null
+  updated_at: string
+}
+
+export interface ContactSubmission {
+  id: string
+  name: string
+  email: string
+  subject: string | null
+  message: string
+  read: boolean
+  created_at: string
+}


### PR DESCRIPTION
## Summary
- Complete admin dashboard implementation (Issue #2)
- Login page with glass morphism design matching the portfolio's visual language
- Sidebar navigation with 10 sections, mobile responsive via Sheet
- CRUD editors for Hero, About, Projects, Skills, Experience, Contact Info, Settings
- Drag-to-reorder for multi-row editors (Projects, Skills, Experience) via @dnd-kit
- Messages viewer with read/unread toggle and inline expansion
- Contact API route (`POST /api/contact`) with Zod validation, wired to the public contact form
- Shared admin components: ImageUpload (Supabase Storage), DynamicList, DynamicKeyValueList
- Database TypeScript types and 7 Zod validation schemas
- Sign in/logout buttons in main site navbar
- Blog and Resume admin stubs for Issues #3 and #4

## Test plan
- [ ] Visit `/login` — verify glass morphism UI, gradient mesh bg, floating orbs
- [ ] Sign in with valid credentials — redirected to `/admin`
- [ ] Dashboard shows stat cards and recent messages
- [ ] Navigate all sidebar links — each page loads correctly
- [ ] Edit Hero/About/Settings — save and verify changes on public site
- [ ] Create/edit/delete a Project — verify drag-to-reorder works
- [ ] Create/edit/delete a Skill — verify category tabs work
- [ ] Create/edit/delete an Experience — verify "Present" checkbox clears end date
- [ ] Upload an image via ImageUpload — verify it appears in Supabase Storage
- [ ] Submit the public contact form — message appears in Messages admin page
- [ ] Mark message as read/unread, delete a message
- [ ] Test mobile responsive: sidebar hidden, accessible via hamburger Sheet
- [ ] Blog/Resume pages show "Coming Soon" stubs
- [ ] Navbar shows "Sign In" when logged out, "Dashboard + Logout" when logged in
- [ ] Logout from navbar and admin sidebar both work

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)