### PR TITLE
feat(seo): dynamic metadata, sitemap, robots, JSON-LD, and GA4

### DIFF
--- a/src/app/(public)/blog/[slug]/page.tsx
+++ b/src/app/(public)/blog/[slug]/page.tsx
@@ -5,6 +5,9 @@ import Image from "next/image"
 import { ArrowLeft, ChevronLeft, ChevronRight } from "lucide-react"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { getBlogPost, getAdjacentPosts } from "@/lib/queries"
+import { getCachedSiteConfig } from "@/lib/seo"
+import { articleJsonLd } from "@/lib/json-ld"
+import { JsonLd } from "@/components/JsonLd"
 import { Badge } from "@/components/ui/badge"
 import { BlogRenderer } from "@/components/blog/blog-renderer"
 import { TableOfContents } from "./table-of-contents"
@@ -30,7 +33,7 @@ export async function generateMetadata({
   const ogImage = post.og_image_url || post.cover_image_url
 
   return {
-    title: `${title} — Alex Rivera`,
+    title,
     description,
     openGraph: {
       title,
@@ -55,6 +58,8 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
 
   if (!post) notFound()
 
+  const config = await getCachedSiteConfig()
+
   const adjacent = post.published_at
     ? await getAdjacentPosts(post.published_at)
     : { prev: null, next: null }
@@ -69,6 +74,9 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
 
   return (
     <main className="min-h-screen pt-24 pb-16">
+      {config && (
+        <JsonLd data={articleJsonLd(post, { name: config.name, siteUrl: config.siteUrl })} />
+      )}
       {/* Cover image */}
       {post.cover_image_url && (
         <div className="container-wide mb-10">

--- a/src/app/(public)/blog/page.tsx
+++ b/src/app/(public)/blog/page.tsx
@@ -1,15 +1,24 @@
 import type { Metadata } from "next"
 import { getBlogPosts, getAllBlogTags } from "@/lib/queries"
+import { getCachedSiteConfig } from "@/lib/seo"
+import { collectionPageJsonLd } from "@/lib/json-ld"
+import { JsonLd } from "@/components/JsonLd"
 import { BlogListing } from "./blog-listing"
 
-export const metadata: Metadata = {
-  title: "Blog — Alex Rivera",
-  description:
-    "Thoughts on code, craft, and the modern web. Articles about React, TypeScript, architecture, and more.",
-  openGraph: {
-    title: "Blog — Alex Rivera",
-    description: "Thoughts on code, craft, and the modern web.",
-  },
+export async function generateMetadata(): Promise<Metadata> {
+  const config = await getCachedSiteConfig()
+  const description = config
+    ? `Articles and thoughts by ${config.name} on code, craft, and the modern web.`
+    : "Thoughts on code, craft, and the modern web."
+
+  return {
+    title: "Blog",
+    description,
+    openGraph: {
+      title: config ? `Blog — ${config.name}` : "Blog",
+      description,
+    },
+  }
 }
 
 export default async function BlogPage({
@@ -20,10 +29,15 @@ export default async function BlogPage({
   const { page: pageStr, tag } = await searchParams
   const page = Math.max(1, parseInt(pageStr ?? "1", 10) || 1)
 
-  const [result, allTags] = await Promise.all([getBlogPosts(page, tag), getAllBlogTags()])
+  const [result, allTags, config] = await Promise.all([
+    getBlogPosts(page, tag),
+    getAllBlogTags(),
+    getCachedSiteConfig(),
+  ])
 
   return (
     <main className="min-h-screen pt-24 pb-16">
+      {config && <JsonLd data={collectionPageJsonLd(config)} />}
       <div className="container-wide">
         <div className="mb-12">
           <h1 className="mb-3 text-[length:var(--text-4xl)] font-bold">Blog</h1>

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next"
 import { Hero } from "@/components/sections/Hero"
 import { About } from "@/components/sections/About"
 import { Projects } from "@/components/sections/Projects"
@@ -5,6 +6,9 @@ import { Skills } from "@/components/sections/Skills"
 import { Experience } from "@/components/sections/Experience"
 import { Blog } from "@/components/sections/Blog"
 import { Contact } from "@/components/sections/Contact"
+import { JsonLd } from "@/components/JsonLd"
+import { getCachedSiteConfig } from "@/lib/seo"
+import { personAndWebsiteJsonLd } from "@/lib/json-ld"
 import {
   getSiteConfig,
   getHeroData,
@@ -15,20 +19,39 @@ import {
   getBlogData,
 } from "@/lib/queries"
 
+export async function generateMetadata(): Promise<Metadata> {
+  const config = await getCachedSiteConfig()
+  if (!config) return {}
+
+  return {
+    title: { absolute: config.siteTitle },
+  }
+}
+
 export default async function Home() {
-  const [siteConfig, heroData, aboutData, projectsData, skillsData, experienceData, blogData] =
-    await Promise.all([
-      getSiteConfig(),
-      getHeroData(),
-      getAboutData(),
-      getProjectsData(),
-      getSkillsData(),
-      getExperienceData(),
-      getBlogData(),
-    ])
+  const [
+    siteConfig,
+    heroData,
+    aboutData,
+    projectsData,
+    skillsData,
+    experienceData,
+    blogData,
+    seoConfig,
+  ] = await Promise.all([
+    getSiteConfig(),
+    getHeroData(),
+    getAboutData(),
+    getProjectsData(),
+    getSkillsData(),
+    getExperienceData(),
+    getBlogData(),
+    getCachedSiteConfig(),
+  ])
 
   return (
     <main>
+      {seoConfig && <JsonLd data={personAndWebsiteJsonLd(seoConfig)} />}
       <Hero heroData={heroData} siteConfig={siteConfig} />
       <About
         aboutData={aboutData}

--- a/src/app/(public)/resume/page.tsx
+++ b/src/app/(public)/resume/page.tsx
@@ -1,29 +1,40 @@
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 import { getResumeData, getResumeSkills, getResumeExperience } from "@/lib/queries"
+import { getCachedSiteConfig } from "@/lib/seo"
+import { profilePageJsonLd } from "@/lib/json-ld"
+import { JsonLd } from "@/components/JsonLd"
 import { ResumePublicView } from "@/components/resume/ResumePublicView"
 
-export const metadata: Metadata = {
-  title: "Resume — Alex Rivera",
-  description:
-    "Professional resume and work experience of Alex Rivera, Senior Full-Stack Developer.",
-  openGraph: {
-    title: "Resume — Alex Rivera",
-    description: "Professional resume and work experience of Alex Rivera.",
-  },
+export async function generateMetadata(): Promise<Metadata> {
+  const config = await getCachedSiteConfig()
+  const description = config
+    ? `Professional resume and work experience of ${config.name}.`
+    : "Professional resume and work experience."
+
+  return {
+    title: "Resume",
+    description,
+    openGraph: {
+      title: config ? `Resume — ${config.name}` : "Resume",
+      description,
+    },
+  }
 }
 
 export default async function ResumePage() {
-  const [resume, skills, experience] = await Promise.all([
+  const [resume, skills, experience, config] = await Promise.all([
     getResumeData(),
     getResumeSkills(),
     getResumeExperience(),
+    getCachedSiteConfig(),
   ])
 
   if (!resume) return notFound()
 
   return (
     <main className="min-h-screen pt-24 pb-16">
+      {config && <JsonLd data={profilePageJsonLd(config)} />}
       <div className="container-wide">
         <ResumePublicView data={resume} skills={skills} experience={experience} />
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
-import type { Metadata } from "next"
 import { Geist, Geist_Mono } from "next/font/google"
 import { Providers } from "@/components/Providers"
-import { JsonLd } from "@/components/JsonLd"
+import { GoogleAnalytics } from "@/components/GoogleAnalytics"
+import { buildRootMetadata, getCachedSiteConfig } from "@/lib/seo"
 import "./globals.css"
 
 const geistSans = Geist({
@@ -14,74 +14,22 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 })
 
-export const metadata: Metadata = {
-  metadataBase: new URL("https://alexrivera.dev"),
-  title: "Alex Rivera — Senior Full-Stack Developer",
-  description:
-    "I craft performant, elegant web experiences that push the boundaries of what's possible on the modern web. Specializing in React, Node.js, and cloud architecture.",
-  keywords: [
-    "Full-Stack Developer",
-    "React",
-    "Next.js",
-    "TypeScript",
-    "Node.js",
-    "Portfolio",
-    "Software Engineer",
-  ],
-  authors: [{ name: "Alex Rivera" }],
-  creator: "Alex Rivera",
-  openGraph: {
-    type: "website",
-    locale: "en_US",
-    url: "https://alexrivera.dev",
-    siteName: "Alex Rivera",
-    title: "Alex Rivera — Senior Full-Stack Developer",
-    description:
-      "I craft performant, elegant web experiences that push the boundaries of what's possible on the modern web.",
-    images: [
-      {
-        url: "/og-image.jpg",
-        width: 1200,
-        height: 630,
-        alt: "Alex Rivera — Senior Full-Stack Developer",
-      },
-    ],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Alex Rivera — Senior Full-Stack Developer",
-    description:
-      "I craft performant, elegant web experiences that push the boundaries of what's possible on the modern web.",
-    images: ["/og-image.jpg"],
-  },
-  robots: {
-    index: true,
-    follow: true,
-    googleBot: {
-      index: true,
-      follow: true,
-      "max-video-preview": -1,
-      "max-image-preview": "large",
-      "max-snippet": -1,
-    },
-  },
-  alternates: {
-    types: {
-      "application/rss+xml": "/blog/feed.xml",
-    },
-  },
+export async function generateMetadata() {
+  return buildRootMetadata()
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const config = await getCachedSiteConfig()
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}>
         <Providers>{children}</Providers>
-        <JsonLd />
+        {config?.googleAnalyticsId && <GoogleAnalytics gaId={config.googleAnalyticsId} />}
       </body>
     </html>
   )

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next"
+
+export default function robots(): MetadataRoute.Robots {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? ""
+
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/admin/", "/api/", "/login"],
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,30 @@
+import type { MetadataRoute } from "next"
+import { createAdminClient } from "@/lib/supabase/admin"
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? ""
+
+  // Static pages
+  const staticPages: MetadataRoute.Sitemap = [
+    { url: siteUrl, changeFrequency: "weekly", priority: 1.0 },
+    { url: `${siteUrl}/blog`, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${siteUrl}/resume`, changeFrequency: "monthly", priority: 0.6 },
+  ]
+
+  // Dynamic: published blog posts
+  const supabase = createAdminClient()
+  const { data: posts } = await supabase
+    .from("blog_posts")
+    .select("slug, updated_at")
+    .eq("published", true)
+    .order("published_at", { ascending: false })
+
+  const blogPages: MetadataRoute.Sitemap = (posts ?? []).map((post) => ({
+    url: `${siteUrl}/blog/${post.slug}`,
+    lastModified: post.updated_at ? new Date(post.updated_at) : undefined,
+    changeFrequency: "monthly",
+    priority: 0.7,
+  }))
+
+  return [...staticPages, ...blogPages]
+}

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,0 +1,15 @@
+import Script from "next/script"
+
+export function GoogleAnalytics({ gaId }: { gaId: string }) {
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+        strategy="afterInteractive"
+      />
+      <Script id="ga-init" strategy="afterInteractive">
+        {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','${gaId}')`}
+      </Script>
+    </>
+  )
+}

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,22 +1,23 @@
-import Script from "next/script"
+/**
+ * Generic JSON-LD renderer — server component.
+ * Renders structured data inline so crawlers see it immediately.
+ *
+ * Safe to use dangerouslySetInnerHTML here because JSON.stringify()
+ * output cannot contain unescaped HTML — script[type=application/ld+json]
+ * is not parsed as HTML by the browser.
+ */
+export function JsonLd({ data }: { data: Record<string, unknown> | Record<string, unknown>[] }) {
+  const items = Array.isArray(data) ? data : [data]
 
-const jsonLd = {
-  "@context": "https://schema.org",
-  "@type": "Person",
-  name: "Alex Rivera",
-  url: "https://alexrivera.dev",
-  jobTitle: "Senior Full-Stack Developer",
-  sameAs: [
-    "https://github.com/alexrivera",
-    "https://linkedin.com/in/alexrivera",
-    "https://x.com/alexrivera",
-  ],
-}
-
-export function JsonLd() {
   return (
-    <Script id="json-ld" type="application/ld+json" strategy="afterInteractive">
-      {JSON.stringify(jsonLd)}
-    </Script>
+    <>
+      {items.map((item, i) => (
+        <script
+          key={i}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(item) }}
+        />
+      ))}
+    </>
   )
 }

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -1,0 +1,99 @@
+import type { SiteConfig } from "@/lib/seo"
+
+/**
+ * Person + WebSite schema for the home page.
+ */
+export function personAndWebsiteJsonLd(config: SiteConfig) {
+  const sameAs = Object.values(config.socials).filter(Boolean)
+
+  return [
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      name: config.name,
+      url: config.siteUrl,
+      ...(config.avatarUrl && { image: config.avatarUrl }),
+      ...(config.siteDescription && { description: config.siteDescription }),
+      ...(sameAs.length > 0 && { sameAs }),
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      name: config.siteTitle,
+      url: config.siteUrl,
+      ...(config.siteDescription && { description: config.siteDescription }),
+    },
+  ]
+}
+
+/**
+ * Article schema for individual blog posts.
+ */
+export function articleJsonLd(
+  post: {
+    title: string
+    slug: string
+    excerpt?: string | null
+    published_at?: string | null
+    updated_at?: string | null
+    cover_image_url?: string | null
+    tags?: string[]
+  },
+  author: { name: string; siteUrl: string },
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: post.title,
+    url: `${author.siteUrl}/blog/${post.slug}`,
+    ...(post.excerpt && { description: post.excerpt }),
+    ...(post.published_at && { datePublished: post.published_at }),
+    ...(post.updated_at && { dateModified: post.updated_at }),
+    ...(post.cover_image_url && { image: post.cover_image_url }),
+    ...(post.tags && post.tags.length > 0 && { keywords: post.tags.join(", ") }),
+    author: {
+      "@type": "Person",
+      name: author.name,
+      url: author.siteUrl,
+    },
+  }
+}
+
+/**
+ * CollectionPage schema for the blog index.
+ */
+export function collectionPageJsonLd(config: SiteConfig) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: `Blog — ${config.name}`,
+    url: `${config.siteUrl}/blog`,
+    description: `Articles and thoughts by ${config.name}`,
+    isPartOf: {
+      "@type": "WebSite",
+      name: config.siteTitle,
+      url: config.siteUrl,
+    },
+  }
+}
+
+/**
+ * ProfilePage schema for the resume page.
+ */
+export function profilePageJsonLd(config: SiteConfig) {
+  const sameAs = Object.values(config.socials).filter(Boolean)
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    name: `Resume — ${config.name}`,
+    url: `${config.siteUrl}/resume`,
+    mainEntity: {
+      "@type": "Person",
+      name: config.name,
+      url: config.siteUrl,
+      ...(config.siteDescription && { description: config.siteDescription }),
+      ...(sameAs.length > 0 && { sameAs }),
+    },
+  }
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,102 @@
+import { cache } from "react"
+import type { Metadata } from "next"
+import { createClient } from "@/lib/supabase/server"
+
+export interface SiteConfig {
+  siteTitle: string
+  siteDescription: string
+  ogImageUrl: string
+  googleAnalyticsId: string
+  socials: Record<string, string>
+  avatarUrl: string
+  name: string
+  siteUrl: string
+}
+
+/**
+ * Cached site config fetcher — deduplicates Supabase calls within a single request.
+ * Safe to call from both generateMetadata() and page components.
+ */
+export const getCachedSiteConfig = cache(async (): Promise<SiteConfig | null> => {
+  const supabase = await createClient()
+  const [{ data: settings }, { data: hero }] = await Promise.all([
+    supabase.from("site_settings").select("*").single(),
+    supabase.from("hero_section").select("name, avatar_url").single(),
+  ])
+
+  if (!settings || !hero) return null
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? ""
+
+  return {
+    siteTitle: settings.site_title ?? "",
+    siteDescription: settings.site_description ?? "",
+    ogImageUrl: settings.og_image_url ?? "",
+    googleAnalyticsId: settings.google_analytics_id ?? "",
+    socials: (settings.social_links as Record<string, string>) ?? {},
+    avatarUrl: hero.avatar_url ?? "",
+    name: hero.name ?? "",
+    siteUrl,
+  }
+})
+
+/**
+ * Builds the root metadata object for the site.
+ * Used in app/layout.tsx generateMetadata().
+ */
+export async function buildRootMetadata(): Promise<Metadata> {
+  const config = await getCachedSiteConfig()
+
+  if (!config) {
+    return {
+      title: "Portfolio",
+      description: "Personal portfolio website",
+    }
+  }
+
+  const { siteTitle, siteDescription, ogImageUrl, name, siteUrl } = config
+
+  return {
+    metadataBase: siteUrl ? new URL(siteUrl) : undefined,
+    title: {
+      default: siteTitle,
+      template: `%s — ${name}`,
+    },
+    description: siteDescription,
+    authors: [{ name }],
+    creator: name,
+    openGraph: {
+      type: "website",
+      locale: "en_US",
+      url: siteUrl || undefined,
+      siteName: name,
+      title: siteTitle,
+      description: siteDescription,
+      ...(ogImageUrl && {
+        images: [{ url: ogImageUrl, width: 1200, height: 630, alt: siteTitle }],
+      }),
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: siteTitle,
+      description: siteDescription,
+      ...(ogImageUrl && { images: [ogImageUrl] }),
+    },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        "max-video-preview": -1,
+        "max-image-preview": "large",
+        "max-snippet": -1,
+      },
+    },
+    alternates: {
+      types: {
+        "application/rss+xml": "/blog/feed.xml",
+      },
+    },
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextResponse, type NextRequest } from "next/server"
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request })
 
   const supabase = createServerClient(
@@ -13,7 +13,7 @@ export async function middleware(request: NextRequest) {
           return request.cookies.getAll()
         },
         setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) => request.cookies.set(name, value))
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
           supabaseResponse = NextResponse.next({ request })
           cookiesToSet.forEach(({ name, value, options }) =>
             supabaseResponse.cookies.set(name, value, options),


### PR DESCRIPTION
## Summary
- Replace all hardcoded SEO metadata with dynamic values from Supabase (`getCachedSiteConfig()` with `React.cache()`)
- Add `sitemap.xml` (static pages + published blog posts) and `robots.txt` (disallow admin/api/login)
- Add per-page JSON-LD structured data: Person+WebSite (home), CollectionPage (blog), Article (posts), ProfilePage (resume)
- Wire up conditional Google Analytics from admin settings
- Migrate `middleware.ts` → `proxy.ts` to fix Next.js 16 deprecation warning
- Make RSS feed title/description dynamic from DB

Closes #6

## Test plan
- [ ] `npm run build` — clean, no errors or warnings
- [ ] `/sitemap.xml` returns valid XML with all pages + blog posts
- [ ] `/robots.txt` disallows `/admin/`, `/api/`, `/login` and includes sitemap
- [ ] Homepage `<title>` uses DB values, JSON-LD Person+WebSite present
- [ ] `/blog` title is "Blog — {name}", CollectionPage JSON-LD present
- [ ] `/blog/{slug}` has Article JSON-LD with headline, datePublished, author
- [ ] `/resume` title is "Resume — {name}", ProfilePage JSON-LD present
- [ ] No hardcoded "Alex Rivera" or "alexrivera.dev" in any page output
- [ ] `/blog/feed.xml` uses dynamic title from DB
- [ ] If GA ID set in admin, gtag script appears in HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)