### PR TITLE
fix: resolve all ESLint errors and warnings

### DIFF
--- a/src/app/admin/blog/blog-post-form.tsx
+++ b/src/app/admin/blog/blog-post-form.tsx
@@ -1,4 +1,5 @@
 "use client"
+"use no memo" // React Hook Form's watch() is incompatible with React Compiler
 
 import { useState, useEffect, useRef, useTransition, useCallback } from "react"
 import { useRouter } from "next/navigation"
@@ -61,6 +62,7 @@ export function BlogPostForm({ data }: BlogPostFormProps) {
   })
 
   // Track content changes for read time / excerpt auto-generation
+  // eslint-disable-next-line react-hooks/incompatible-library -- React Hook Form watch() is intentionally reactive
   const content = form.watch("content")
   const title = form.watch("title")
   const published = form.watch("published")

--- a/src/components/CustomCursor.tsx
+++ b/src/components/CustomCursor.tsx
@@ -1,22 +1,29 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState, useSyncExternalStore } from "react"
 import gsap from "gsap"
+
+const TOUCH_QUERY = "(pointer: coarse)"
+
+function subscribeTouchChange(callback: () => void) {
+  const mq = window.matchMedia(TOUCH_QUERY)
+  mq.addEventListener("change", callback)
+  return () => mq.removeEventListener("change", callback)
+}
+
+function getIsTouch() {
+  return window.matchMedia(TOUCH_QUERY).matches
+}
 
 export function CustomCursor() {
   const cursorRef = useRef<HTMLDivElement>(null)
   const cursorDotRef = useRef<HTMLDivElement>(null)
   const [isHovering, setIsHovering] = useState(false)
   const [isVisible, setIsVisible] = useState(false)
-  const [isTouch, setIsTouch] = useState(false)
+  const isTouch = useSyncExternalStore(subscribeTouchChange, getIsTouch, () => false)
 
   useEffect(() => {
-    if (typeof window === "undefined") return
-    const hasCoarsePointer = window.matchMedia("(pointer: coarse)").matches
-    if (hasCoarsePointer) {
-      setIsTouch(true)
-      return
-    }
+    if (isTouch) return
 
     const moveCursor = (e: MouseEvent) => {
       if (!isVisible) setIsVisible(true)
@@ -61,7 +68,7 @@ export function CustomCursor() {
         el.removeEventListener("mouseleave", handleMouseLeave)
       })
     }
-  }, [isVisible])
+  }, [isVisible, isTouch])
 
   if (isTouch) return null
 

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,14 +1,22 @@
 "use client"
 
 import { useTheme } from "next-themes"
-import { useEffect, useState } from "react"
+import { useSyncExternalStore } from "react"
 import { motion, AnimatePresence } from "motion/react"
+
+const emptySubscribe = () => () => {}
+
+function useMounted() {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  )
+}
 
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme()
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => setMounted(true), [])
+  const mounted = useMounted()
 
   if (!mounted) {
     return <button className="relative h-9 w-9 rounded-full" aria-label="Toggle theme" />

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -165,11 +165,12 @@ export function Hero({ heroData: heroDataProp, siteConfig: siteConfigProp }: Her
 
   // Rotating role text
   useEffect(() => {
+    if (heroData.roles.length === 0) return
     const interval = setInterval(() => {
       setRoleIndex((prev) => (prev + 1) % heroData.roles.length)
     }, 3000)
     return () => clearInterval(interval)
-  }, [])
+  }, [heroData.roles.length])
 
   return (
     <section ref={sectionRef} className="relative flex min-h-screen items-center overflow-hidden">

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,18 +1,23 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useSyncExternalStore } from "react"
+
+const QUERY = "(prefers-reduced-motion: reduce)"
+
+function subscribe(callback: () => void) {
+  const mq = window.matchMedia(QUERY)
+  mq.addEventListener("change", callback)
+  return () => mq.removeEventListener("change", callback)
+}
+
+function getSnapshot() {
+  return window.matchMedia(QUERY).matches
+}
+
+function getServerSnapshot() {
+  return false
+}
 
 export function useReducedMotion(): boolean {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
-
-  useEffect(() => {
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)")
-    setPrefersReducedMotion(mq.matches)
-
-    const handler = (e: MediaQueryListEvent) => setPrefersReducedMotion(e.matches)
-    mq.addEventListener("change", handler)
-    return () => mq.removeEventListener("change", handler)
-  }, [])
-
-  return prefersReducedMotion
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }


### PR DESCRIPTION
## Summary
- Replace `setState`-in-effect with `useSyncExternalStore` in `useReducedMotion`, `ThemeToggle`, and `CustomCursor`
- Add missing `heroData.roles.length` dependency in `Hero` useEffect
- Suppress React Hook Form `incompatible-library` warning with `eslint-disable` + `"use no memo"` directive

## Test plan
- [ ] `npm run lint` — 0 errors, 0 warnings
- [ ] `npx tsc --noEmit` — passes
- [ ] Theme toggle still works (light/dark)
- [ ] Custom cursor works on desktop, hidden on touch
- [ ] Reduced motion preference respected
- [ ] Hero role rotation still cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)