### PR TITLE
feat(resume): selectable achievement bullet points

### DIFF
--- a/src/app/api/resume/download/route.ts
+++ b/src/app/api/resume/download/route.ts
@@ -64,7 +64,7 @@ export async function GET() {
       location: e.location as string | null,
       period: `${startStr} – ${endStr}`,
       description: e.description as string | null,
-      achievements: (e.achievements ?? []) as string[],
+      achievements: ((e.resume_achievements ?? e.achievements ?? []) as string[]),
     }
   })
 

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -479,7 +479,7 @@ export async function getResumeExperience() {
       location: e.location,
       period: `${startStr} – ${endStr}`,
       description: e.description,
-      achievements: e.achievements ?? [],
+      achievements: e.resume_achievements ?? e.achievements ?? [],
       company_url: e.company_url,
     }
   })

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -110,6 +110,7 @@ export interface Experience {
   end_date: string | null
   description: string | null
   achievements: string[]
+  resume_achievements: string[] | null
   company_logo_url: string | null
   company_url: string | null
   employment_type: string

--- a/supabase/migrations/20260213000000_experience_resume_achievements.sql
+++ b/supabase/migrations/20260213000000_experience_resume_achievements.sql
@@ -1,0 +1,4 @@
+-- Allow selecting which achievement bullets appear on the resume.
+-- NULL = show all achievements (backward-compatible default).
+-- Empty array = show none. Populated array = show only those.
+ALTER TABLE experience ADD COLUMN resume_achievements TEXT[] DEFAULT NULL;


### PR DESCRIPTION
## Summary
- Adds `resume_achievements` column to the `experience` table (new migration)
- Admin resume page now shows expandable bullet-point checkboxes per experience entry — select which achievements appear on the resume
- `NULL` = show all (backward-compatible), populated array = show only selected
- Preview, PDF generation, public view, and download route all filter through `resume_achievements`

## Test plan
- [ ] Run `supabase db push` — migration applies
- [ ] Visit `/admin/resume` — toggle an experience ON, see bullet checkboxes expand
- [ ] Uncheck some bullets — preview updates in real-time
- [ ] Toggle experience OFF → back ON → all bullets default to checked
- [ ] Generate PDF → only selected bullets appear
- [ ] Visit `/resume` → only selected bullets show
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)