### PR TITLE
fix(auth): add dedicated reset password page

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -10,6 +10,11 @@ export async function GET(request: Request) {
     const supabase = await createClient()
     const { error } = await supabase.auth.exchangeCodeForSession(code)
     if (!error) {
+      // For password recovery, redirect to the reset password page
+      // instead of the admin dashboard
+      if (next === "/reset-password") {
+        return NextResponse.redirect(`${origin}/reset-password`)
+      }
       return NextResponse.redirect(`${origin}${next}`)
     }
   }

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -22,7 +22,7 @@ export async function resetPassword(email: string) {
   const supabase = await createClient()
 
   const { error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/api/auth/callback?next=/admin`,
+    redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/api/auth/callback?next=/reset-password`,
   })
 
   if (error) {

--- a/src/app/reset-password/actions.ts
+++ b/src/app/reset-password/actions.ts
@@ -1,0 +1,16 @@
+"use server"
+
+import { redirect } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
+
+export async function updatePassword(password: string) {
+  const supabase = await createClient()
+
+  const { error } = await supabase.auth.updateUser({ password })
+
+  if (error) {
+    return { error: error.message }
+  }
+
+  redirect("/admin")
+}

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,0 +1,106 @@
+import Link from "next/link"
+import { redirect } from "next/navigation"
+import { ArrowLeft } from "lucide-react"
+import { createClient } from "@/lib/supabase/server"
+import { ResetPasswordForm } from "./reset-password-form"
+
+export default async function ResetPasswordPage() {
+  // Ensure the user has a valid recovery session
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect("/login")
+  }
+
+  return (
+    <div className="bg-background relative flex min-h-screen items-center justify-center overflow-hidden p-4">
+      {/* Gradient mesh background — matches Login */}
+      <div className="gradient-mesh absolute inset-0 -z-10" />
+
+      {/* Animated floating orbs */}
+      <div className="absolute inset-0 -z-[5] overflow-hidden" aria-hidden="true">
+        <div
+          className="login-orb-1 absolute top-[15%] left-[10%] h-72 w-72 rounded-full opacity-20 blur-3xl"
+          style={{ background: "oklch(0.7 0.25 264 / 40%)" }}
+        />
+        <div
+          className="login-orb-2 absolute right-[10%] bottom-[15%] h-96 w-96 rounded-full opacity-15 blur-3xl"
+          style={{ background: "oklch(0.7 0.2 330 / 30%)" }}
+        />
+      </div>
+
+      {/* Subtle grid */}
+      <div className="absolute inset-0 -z-10 opacity-[0.02]">
+        <div
+          className="h-full w-full"
+          style={{
+            backgroundImage: `
+              linear-gradient(var(--foreground) 1px, transparent 1px),
+              linear-gradient(90deg, var(--foreground) 1px, transparent 1px)
+            `,
+            backgroundSize: "60px 60px",
+          }}
+        />
+      </div>
+
+      {/* Noise overlay */}
+      <div className="noise-overlay pointer-events-none" />
+
+      {/* Back to login */}
+      <Link
+        href="/login"
+        className="text-muted-foreground hover:text-foreground absolute top-6 left-6 z-10 flex items-center gap-2 text-sm transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to login
+      </Link>
+
+      {/* Reset card */}
+      <div className="relative w-full max-w-[400px]">
+        {/* Glow behind card */}
+        <div
+          className="absolute -inset-px -z-10 rounded-2xl opacity-60 blur-xl"
+          style={{
+            background:
+              "linear-gradient(135deg, oklch(0.7 0.25 264 / 20%), oklch(0.7 0.2 330 / 15%))",
+          }}
+          aria-hidden="true"
+        />
+
+        <div className="glass rounded-2xl p-8 sm:p-10">
+          {/* Header */}
+          <div className="mb-8 text-center">
+            <div className="bg-primary/10 ring-primary/20 mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl ring-1">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="22"
+                height="22"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-primary"
+              >
+                <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
+                <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+              </svg>
+            </div>
+            <h1 className="text-[length:var(--text-xl)] font-semibold tracking-tight">
+              Set new password
+            </h1>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Choose a strong password for your account
+            </p>
+          </div>
+
+          <ResetPasswordForm />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/reset-password/reset-password-form.tsx
+++ b/src/app/reset-password/reset-password-form.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { toast } from "sonner"
+import { Eye, EyeOff, Loader2, Check } from "lucide-react"
+import { updatePassword } from "./actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+
+const resetSchema = z
+  .object({
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirm: z.string(),
+  })
+  .refine((data) => data.password === data.confirm, {
+    message: "Passwords do not match",
+    path: ["confirm"],
+  })
+
+type ResetValues = z.input<typeof resetSchema>
+
+export function ResetPasswordForm() {
+  const [isPending, startTransition] = useTransition()
+  const [showPassword, setShowPassword] = useState(false)
+
+  const form = useForm<ResetValues>({
+    resolver: zodResolver(resetSchema),
+    defaultValues: { password: "", confirm: "" },
+  })
+
+  function onSubmit(values: ResetValues) {
+    startTransition(async () => {
+      const result = await updatePassword(values.password)
+      if (result?.error) {
+        toast.error(result.error)
+      }
+    })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
+                New Password
+              </FormLabel>
+              <FormControl>
+                <div className="relative">
+                  <Input
+                    type={showPassword ? "text" : "password"}
+                    placeholder="Enter new password"
+                    autoComplete="new-password"
+                    className="border-border/50 bg-background/50 focus-visible:border-primary/50 focus-visible:bg-background/80 h-11 rounded-xl px-4 pr-11 text-sm backdrop-blur-sm transition-all"
+                    {...field}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="text-muted-foreground/50 hover:text-muted-foreground absolute top-1/2 right-3 -translate-y-1/2 transition-colors"
+                    tabIndex={-1}
+                  >
+                    {showPassword ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </button>
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="confirm"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
+                Confirm Password
+              </FormLabel>
+              <FormControl>
+                <Input
+                  type={showPassword ? "text" : "password"}
+                  placeholder="Confirm new password"
+                  autoComplete="new-password"
+                  className="border-border/50 bg-background/50 focus-visible:border-primary/50 focus-visible:bg-background/80 h-11 rounded-xl px-4 text-sm backdrop-blur-sm transition-all"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button
+          type="submit"
+          disabled={isPending}
+          className="h-11 w-full rounded-xl text-sm font-medium tracking-wide transition-all"
+        >
+          {isPending ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Updating...
+            </>
+          ) : (
+            <>
+              Update Password
+              <Check className="h-4 w-4" />
+            </>
+          )}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -37,6 +37,13 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(loginUrl)
   }
 
+  // Protect /reset-password — redirect to /login if no recovery session
+  if (pathname === "/reset-password" && !user) {
+    const loginUrl = request.nextUrl.clone()
+    loginUrl.pathname = "/login"
+    return NextResponse.redirect(loginUrl)
+  }
+
   // Redirect /login to /admin if already authenticated
   if (pathname === "/login" && user) {
     const adminUrl = request.nextUrl.clone()
@@ -48,5 +55,5 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/admin/:path*", "/login"],
+  matcher: ["/admin/:path*", "/login", "/reset-password"],
 }


### PR DESCRIPTION
## Summary
- Fixes broken password reset flow — clicking the email link now redirects to a dedicated `/reset-password` page instead of directly to `/admin`
- New page matches the login page styling (glass card, gradient background, floating orbs)
- Form includes password + confirm with 8-character minimum validation
- Proxy protects `/reset-password` route (requires recovery session)

## Flow
```
Forgot? → email sent → click link → /api/auth/callback → session established → /reset-password → enter new password → /admin
```

## Test plan
- [ ] Click "Forgot?" on login, enter email, receive reset email
- [ ] Click email link → lands on `/reset-password` page (not `/admin`)
- [ ] Enter mismatched passwords → validation error
- [ ] Enter valid password → redirected to `/admin`
- [ ] Visit `/reset-password` without recovery session → redirected to `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)