### PR TITLE
feat: multi-agent career AI system with Bedrock + Vercel AI SDK

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -10,5 +10,8 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 REVALIDATION_SECRET=your-revalidation-secret
 
 
-# Anthropic API Key
+# Anthropic API Key (legacy — used by existing services in services.ts)
 ANTHROPIC_API_KEY=your-anthropic-api-key
+
+# Amazon Bedrock API Key (used by multi-agent system via Vercel AI SDK)
+AWS_BEARER_TOKEN_BEDROCK=your-bedrock-api-key

--- a/docs/plans/07-multi-agent-system-plan.md
+++ b/docs/plans/07-multi-agent-system-plan.md
@@ -1,0 +1,199 @@
+# Multi-Agent System — Execution Plan
+
+> Generated from `specs/07-MULTI-AGENT-SYSTEM.md` after codebase audit and multi-perspective review.
+
+---
+
+## Phase 1: Foundation (SDK Migration)
+
+### Issue 1.1: Install Vercel AI SDK + Amazon Bedrock dependencies
+- **Files:** `package.json`
+- **Requirement:** Install `ai` and `@ai-sdk/amazon-bedrock`. No `@aws-sdk/credential-providers` needed (using Bedrock API key auth). Verify `zod` v4 compatibility with the `ai` SDK's `tool()` function.
+- **Command:** `npm install ai @ai-sdk/amazon-bedrock`
+- **Verification:** `npm ls ai @ai-sdk/amazon-bedrock` shows installed versions. `npx tsc --noEmit` passes.
+
+### Issue 1.2: Configure Bedrock API key + create provider module
+- **Files:**
+  - `.env.local` — Add `AWS_BEARER_TOKEN_BEDROCK`
+  - `.env.example` — Add placeholder
+  - Create `src/lib/ai/provider.ts` — Re-export `bedrock` from `@ai-sdk/amazon-bedrock` (zero-config, auto-reads env var)
+  - Create `src/lib/ai/models.ts` — Model registry with `AVAILABLE_MODELS` map (label, provider, tier, capabilities), `getModel(id?)`, `getModelInfo(id)` exports
+- **Requirement:** Provider is zero-config (auto-reads `AWS_BEARER_TOKEN_BEDROCK` for Bearer auth). Model registry includes at least 5 models: Claude Sonnet 4, Claude 3.5 Sonnet v2, Claude 3.5 Haiku, Amazon Nova Pro, Llama 3 70B. Each entry has `tier` (premium/standard/fast) for cost-aware routing. Keep existing `src/lib/resume-builder/ai/client.ts` untouched.
+- **Verification:** Import and call `getModel()`, confirm no TypeScript errors.
+
+### Issue 1.3: Create test API route to verify Bedrock SDK
+- **Files:**
+  - Create `src/app/api/agents/test/route.ts`
+- **Requirement:** Simple `POST` route using `streamText()` from Vercel AI SDK with the Bedrock provider. Tests with `us.anthropic.claude-3-5-haiku-20241022-v1:0` (cheapest). Returns streaming response. Auth-guarded.
+- **Verification:** `curl` or browser test returns streamed text. Remove route after verification.
+
+---
+
+## Phase 2: Shared Agent Chat Components
+
+### Issue 2.1: Build AgentChat core component
+- **Files:**
+  - Create `src/components/agent-chat/agent-chat.tsx`
+  - Create `src/components/agent-chat/index.ts` (barrel export)
+- **Requirement:** React client component using `useChat()` from `ai/react`. Props: `apiEndpoint`, `initialMessages?`, `onToolResult?`, `className?`. Handles streaming, error states, loading indicator. Auto-scroll to bottom on new messages.
+- **Verification:** Renders in Storybook or test page with mock endpoint.
+
+### Issue 2.2: Build MessageBubble component
+- **Files:**
+  - Create `src/components/agent-chat/message-bubble.tsx`
+- **Requirement:** Renders user/assistant messages. Supports markdown (use existing markdown renderer or `react-markdown`). Detects and delegates special blocks (mermaid, JSON) to sub-components. Timestamps. Copy button for assistant messages.
+- **Verification:** Renders markdown, code blocks, and plain text correctly.
+
+### Issue 2.3: Build ToolCallCard component
+- **Files:**
+  - Create `src/components/agent-chat/tool-call-card.tsx`
+- **Requirement:** Renders tool call lifecycle: pending (spinner + "Saving experience..."), success (checkmark + summary), error (red + error message). Uses Vercel AI SDK's `toolInvocations` from message parts.
+- **Verification:** Shows correct states for mock tool calls.
+
+### Issue 2.4: Build MermaidBlock component
+- **Files:**
+  - `package.json` (add `mermaid`)
+  - Create `src/components/agent-chat/mermaid-block.tsx`
+- **Requirement:** Install `mermaid` library. Detect ` ```mermaid ` fences. Render diagram via `mermaid.render()` in a `useEffect`. Include raw code toggle button for copy/paste. Handle syntax errors gracefully (show raw code with error message).
+- **Verification:** Renders a valid Mermaid flowchart. Shows error state for invalid syntax.
+
+### Issue 2.5: Build JsonPreview component
+- **Files:**
+  - Create `src/components/agent-chat/json-preview.tsx`
+- **Requirement:** Renders JSON output with syntax highlighting. Collapsible sections. Copy button. Used by Gem 3 to show tailored resume output.
+- **Verification:** Renders a sample `ResumeWithRelations` JSON object with proper formatting.
+
+---
+
+## Phase 3: Prompt Engineer Enhancement
+
+### Issue 3.1: Database migration — extend ai_prompts
+- **Files:**
+  - Create `supabase/migrations/YYYYMMDD_agent_personas.sql`
+- **Requirement:** Add `persona_name TEXT` and `model_id TEXT` columns to `ai_prompts`. Add index on `persona_name`. Run via `npx supabase db push`.
+- **Verification:** Query `SELECT column_name FROM information_schema.columns WHERE table_name = 'ai_prompts'` shows new columns.
+
+### Issue 3.2: Seed agent system prompts
+- **Files:**
+  - Create `supabase/migrations/YYYYMMDD_seed_agent_prompts.sql`
+- **Requirement:** INSERT 4 rows into `ai_prompts`: `career_interviewer`, `enterprise_architect`, `resume_tailor`, `meta_prompt_optimizer`. Use the exact prompt text from the spec. Set `category = 'agent'`, `persona_name` accordingly, `is_default = true`.
+- **Verification:** `SELECT slug, persona_name FROM ai_prompts WHERE category = 'agent'` returns 4 rows.
+
+### Issue 3.3: Update AIPrompt TypeScript types
+- **Files:**
+  - `src/types/ai-prompts.ts`
+- **Requirement:** Add `persona_name: string | null` and `model_id: string | null` to `AIPrompt` interface. Update `category` union type to include `'agent'`.
+- **Verification:** `npx tsc --noEmit` passes.
+
+### Issue 3.4: Implement autoOptimizePrompt server action
+- **Files:**
+  - `src/app/admin/prompt-engineer/actions.ts`
+- **Requirement:** Add `autoOptimizePrompt(draftPrompt: string): Promise<string>` function. Uses `generateText()` from Vercel AI SDK with the meta-prompt from the spec. Returns the optimized prompt text.
+- **Verification:** Call with a simple draft prompt, verify it returns a well-structured XML prompt.
+
+### Issue 3.5: Wire Auto-Optimize to Prompt Engineer UI
+- **Files:**
+  - `src/app/admin/prompt-engineer/prompt-engineer-client.tsx`
+- **Requirement:** Add "Auto-Optimize" button (with sparkle icon) next to the system prompt textarea. On click, calls `autoOptimizePrompt()` with current system prompt text. Shows loading state. Replaces textarea content with the optimized result. User can undo via browser undo or cancel.
+- **Verification:** Click button → system prompt field updates with optimized version.
+
+---
+
+## Phase 4: Gem 1 — The Career Interviewer
+
+### Issue 4.1: Define Zod tool schemas for Career Interviewer
+- **Files:**
+  - Create `src/lib/ai/tools/coach-tools.ts`
+- **Requirement:** Define Zod schemas and `tool()` definitions for: `save_work_experience`, `save_project`, `save_skill_category`, `update_summary`. Each tool's `execute` function performs Supabase INSERTs/UPSERTs using the admin client. All tools require `resumeId` in context.
+- **Verification:** Import schemas, validate sample data, confirm Zod parsing works.
+
+### Issue 4.2: Create streaming Coach API route
+- **Files:**
+  - Create `src/app/api/agents/coach/route.ts`
+- **Requirement:** POST route using `streamText()` with tools from Issue 4.1. Fetches system prompt from `ai_prompts` (slug: `career_interviewer`). Injects existing career data as XML context. Auth-guarded. Logs token usage. Supports `maxDuration: 60` for Vercel.
+- **Verification:** POST with test messages → streaming response with tool calls in the stream.
+
+### Issue 4.3: Refactor Career Coach UI to use AgentChat
+- **Files:**
+  - `src/app/admin/resume-builder/career-coach/[id]/chat-interface.tsx`
+  - `src/app/admin/resume-builder/career-coach/[id]/page.tsx` (if needed)
+- **Requirement:** Replace the existing custom chat UI with `<AgentChat apiEndpoint="/api/agents/coach" />`. Pass `resumeId` as a body parameter. Handle `onToolResult` to show toast notifications ("Experience saved!"). Maintain session list sidebar.
+- **Verification:** Full conversation flow: ask about a company → AI probes → AI triggers save tool → data appears in resume editor.
+
+### Issue 4.4: Message persistence for Coach sessions
+- **Files:**
+  - `src/app/api/agents/coach/route.ts` (add persistence hooks)
+  - OR `src/app/admin/resume-builder/career-coach/[id]/chat-interface.tsx`
+- **Requirement:** Persist messages to `career_coach_sessions.messages` JSONB column. On page load, restore previous messages via `initialMessages` prop. Handle both user messages and tool call results.
+- **Verification:** Start conversation → refresh page → messages are restored.
+
+---
+
+## Phase 5: Gem 2 — The Enterprise Architect
+
+### Issue 5.1: Create Architect page and layout
+- **Files:**
+  - Create `src/app/admin/architect/page.tsx`
+  - Create `src/app/admin/architect/layout.tsx` (if needed)
+- **Requirement:** Server component page that renders `<AgentChat>` pointed at `/api/agents/architect`. Full-width layout. Title: "Enterprise Architect". Sidebar navigation link in admin layout.
+- **Verification:** Navigate to `/admin/architect` → see chat interface.
+
+### Issue 5.2: Create Architect API route
+- **Files:**
+  - Create `src/app/api/agents/architect/route.ts`
+- **Requirement:** POST route using `streamText()`. Fetches system prompt from `ai_prompts` (slug: `enterprise_architect`). Injects user's skill categories as context. Auth-guarded. No tool definitions needed (Architect only outputs text/mermaid).
+- **Verification:** POST with "Design a microservices architecture for an e-commerce platform" → returns streaming text with mermaid code blocks.
+
+### Issue 5.3: Add Architect to admin navigation
+- **Files:**
+  - `src/components/admin/admin-sidebar.tsx` (or equivalent navigation component)
+- **Requirement:** Add "Architect" link to admin sidebar under an "AI Agents" section or similar grouping.
+- **Verification:** Sidebar shows Architect link, navigates to `/admin/architect`.
+
+---
+
+## Phase 6: Gem 3 — The Resume Tailor
+
+### Issue 6.1: Build RAG context builder with token budgeting
+- **Files:**
+  - Create `src/lib/ai/context/career-context.ts`
+- **Requirement:** Function `buildCareerContext(userId: string, maxTokens?: number): Promise<string>` that:
+  1. Fetches all career data via existing portfolio data functions
+  2. Formats as XML
+  3. Estimates token count (~4 chars/token)
+  4. If over budget (default 30K tokens), truncates oldest experiences to title/company/dates only
+  5. Returns the XML string
+- **Verification:** Call with test user → returns XML under token budget.
+
+### Issue 6.2: Define Zod tool schemas for Resume Tailor
+- **Files:**
+  - Create `src/lib/ai/tools/tailor-tools.ts`
+- **Requirement:** Define tools: `analyze_jd` (input: raw text, output: JDAnalysis), `generate_tailored_bullets` (input: experienceId + count, output: string[]), `generate_full_resume` (input: templateId, output: partial ResumeWithRelations). Use Zod schemas matching existing TypeScript types.
+- **Verification:** Schema validation passes for sample inputs/outputs.
+
+### Issue 6.3: Create Tailor API route
+- **Files:**
+  - Create `src/app/api/agents/tailor/route.ts`
+- **Requirement:** POST route using `streamText()` with tools from Issue 6.2. Fetches system prompt from `ai_prompts` (slug: `resume_tailor`). Injects career context via `buildCareerContext()`. Auth-guarded. Logs usage.
+- **Verification:** POST with JD text → streaming response with tool calls for analysis.
+
+### Issue 6.4: Refactor JD Analyzer UI to use AgentChat
+- **Files:**
+  - `src/app/admin/resume-builder/jd-analyzer/jd-analyzer-client.tsx`
+- **Requirement:** Replace existing JD analyzer interface with `<AgentChat>` + `<JsonPreview>` side panel. The chat handles conversational JD analysis. Tool results (especially `generate_full_resume`) render in the JSON preview panel. Maintain existing "Save JD" functionality.
+- **Verification:** Paste JD → `/analyze` → see match analysis → `/full` → see resume JSON in preview panel.
+
+---
+
+## Summary
+
+| Phase | Issues | Key Deliverable |
+|-------|--------|----------------|
+| 1. Foundation | 1.1–1.3 | Bedrock + Vercel AI SDK working with streaming + model registry |
+| 2. Shared Components | 2.1–2.5 | Reusable AgentChat with Mermaid + JSON |
+| 3. Prompt Engineer | 3.1–3.5 | Auto-Optimize feature + agent prompts seeded + model selector |
+| 4. Gem 1 (Interviewer) | 4.1–4.4 | AI interviews user → saves to DB via tools |
+| 5. Gem 2 (Architect) | 5.1–5.3 | AI generates Mermaid diagrams in chat |
+| 6. Gem 3 (Tailor) | 6.1–6.4 | AI tailors resume from JD with RAG context + cache points |
+
+**Total: 22 issues across 6 phases.**

--- a/docs/superpowers/specs/2026-03-10-lighthouse-optimization-design.md
+++ b/docs/superpowers/specs/2026-03-10-lighthouse-optimization-design.md
@@ -1,0 +1,142 @@
+# Lighthouse Optimization — Performance & Accessibility
+
+**Date:** 2026-03-10
+**Baseline Scores:** Performance 64, Accessibility 93, Best Practices 100, SEO 100
+**Target Scores:** Performance ~95+, Accessibility 100
+
+## Baseline Metrics
+
+| Metric | Value | Rating |
+|--------|-------|--------|
+| FCP | 0.3s | Good |
+| LCP | 1.2s | Good |
+| TBT | 950ms | Poor |
+| CLS | 0 | Good |
+| Speed Index | 2.3s | Needs improvement |
+
+## Section 1: Image Optimization
+
+**Problem:** All public-facing `<Image>` components use `unoptimized`, bypassing Next.js/Vercel image optimization. Images served as JPEG at original resolution (e.g., 2731x1536 displayed at 396x221). Total estimated savings: 5,716 KiB.
+
+**Fix:** Remove `unoptimized` from public-facing components and add proper `sizes` attributes.
+
+### Files & Changes
+
+| File | Images | Change |
+|------|--------|--------|
+| `src/components/sections/Projects.tsx` | Card hero, modal hero, architecture, gallery, lightbox (5 instances) | Remove `unoptimized`, add `sizes` per context |
+| `src/components/sections/About.tsx` | Portrait (1 instance) | Remove `unoptimized` (already has `sizes`) |
+| `src/components/sections/Ventures.tsx` | Venture logos (3 instances) | Remove `unoptimized` |
+| `src/components/sections/Experience.tsx` | Company logos (4 instances) | Remove `unoptimized` |
+| `src/components/sections/Credentials.tsx` | Cert images (2 instances) | Remove `unoptimized` |
+| `src/app/(public)/blog/blog-listing.tsx` | Blog thumbnails (1 instance) | Remove `unoptimized` |
+| `src/app/(public)/blog/[slug]/page.tsx` | Blog hero image (1 instance) | Remove `unoptimized` |
+
+Admin components (`admin/projects/`, `admin/blog/`, `admin/ventures/`, `image-upload.tsx`, `multi-image-upload.tsx`) keep `unoptimized` — not measured by Lighthouse and optimization could interfere with upload previews.
+
+### Sizes Attributes
+
+- **Project cards** (3-col grid): `sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"`
+- **Project modal hero** (max-w-4xl = 896px): `sizes="(max-width: 896px) 100vw, 896px"`
+- **Gallery grid** (2-col in modal): `sizes="(max-width: 896px) 50vw, 400px"`
+- **Lightbox**: `sizes="90vw"` (max-w-[90vw])
+- **Architecture diagram**: `sizes="(max-width: 896px) 100vw, 800px"`
+- **Venture logos**: `sizes="280px"` (max-w-full but small)
+- **Experience logos**: Small fixed dimensions, no `sizes` needed (already have explicit width/height)
+
+## Section 2: Mouse Animation Performance
+
+**Problem:** `useMousePosition` hook calls `setState` on every `mousemove` event, causing the Hero component (and its children) to re-render ~60 times/second. `CustomCursor` re-attaches all event listeners when `isVisible` state changes.
+
+### Fix: useMousePosition.ts → ref-based
+
+Rewrite to accept element refs and apply transforms directly:
+
+```typescript
+export function useParallaxOnMouse(
+  refs: { ref: RefObject<HTMLElement>; x: number; y: number }[]
+) {
+  useEffect(() => {
+    let rafId: number
+    const handleMouseMove = (e: MouseEvent) => {
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(() => {
+        const nx = (e.clientX / window.innerWidth - 0.5) * 2
+        const ny = (e.clientY / window.innerHeight - 0.5) * 2
+        refs.forEach(({ ref, x, y }) => {
+          if (ref.current) {
+            ref.current.style.transform = `translate(${nx * x}px, ${ny * y}px)`
+          }
+        })
+      })
+    }
+    window.addEventListener("mousemove", handleMouseMove, { passive: true })
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove)
+      cancelAnimationFrame(rafId)
+    }
+  }, [refs])
+}
+```
+
+No React state, no re-renders. Transforms applied directly to DOM.
+
+### Fix: CustomCursor.tsx
+
+- Replace `isVisible` useState with `useRef<boolean>(false)` — set via `.current` in the mousemove handler, toggle visibility via `cursorRef.current.style.opacity`
+- Remove `isVisible` from useEffect dependency array so listeners attach once
+- Remove `isHovering` useState — apply hover styles directly via GSAP in the mouseenter/mouseleave handlers instead of React state
+
+### Fix: Hero.tsx
+
+- Replace `useMousePosition()` call with `useParallaxOnMouse()` passing refs to the three blob divs
+- Remove `mouse` from render, eliminating inline style recalculation
+
+## Section 3: Accessibility (93 → 100)
+
+### ARIA Violations
+
+**Problem:** `aria-label` on `<span>` (hero-greeting) and `<p>` (tagline) is prohibited. GSAP SplitText adds `aria-label` to preserve readable text after splitting into char/word nodes.
+
+**Fix:** Pass `aria: { label: false }` to SplitText.create() config if supported in the version used. If not, remove the `aria-label` attribute after SplitText runs via `element.removeAttribute('aria-label')`. The split text is still readable to screen readers as individual characters.
+
+**Files:** `Hero.tsx` (lines 98, 117, 150), `TextReveal.tsx` (SplitText usage)
+
+### Contrast Failures
+
+**Problem:** Footer section labels (NAVIGATE, MORE, SOCIAL, VENTURES) use `text-muted-foreground/60` which fails WCAG AA 4.5:1 contrast ratio.
+
+**Fix:** Change `text-muted-foreground/60` → `text-muted-foreground` in `Footer.tsx` at lines 127, 141, 156, 176.
+
+## Section 4: JS Bundle — TBT Reduction
+
+**Problem:** TBT 950ms from 9 long tasks. 4.3s main-thread work, 1.8s JS execution time. GSAP + ScrollTrigger + SplitText + motion all load eagerly.
+
+**Fix:** Dynamic import below-the-fold sections:
+
+```typescript
+// In the landing page
+const Projects = dynamic(() => import("@/components/sections/Projects").then(m => ({ default: m.Projects })))
+const Experience = dynamic(() => import("@/components/sections/Experience").then(m => ({ default: m.Experience })))
+```
+
+This defers parsing of GSAP ScrollTrigger animations for sections not visible on initial load, reducing TBT.
+
+**Files:** Landing page component that assembles all sections (likely `src/app/(public)/page.tsx` or the layout).
+
+## Expected Impact
+
+| Change | Estimated Impact |
+|--------|-----------------|
+| Image optimization | +20-25 perf points (5.7MB → ~500KB) |
+| Mouse animation fix | +5-10 perf points (TBT reduction) |
+| Dynamic imports | +5 perf points (TBT reduction) |
+| Accessibility fixes | +7 accessibility points (93 → 100) |
+| **Total** | **~95+ Performance, 100 Accessibility** |
+
+## Out of Scope
+
+- Cache headers (controlled by Vercel/CDN config, not code changes)
+- Legacy JavaScript elimination (14 KiB, minimal impact)
+- DOM size optimization (not a major contributor at current size)
+- Admin dashboard image optimization

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "lenis": "^1.3.17",
         "lowlight": "^3.3.0",
         "lucide-react": "^0.563.0",
+        "mermaid": "^11.12.3",
         "motion": "^12.33.0",
         "next": "16.1.6",
         "next-themes": "^0.4.6",
@@ -186,6 +187,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -531,6 +545,51 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.1.tgz",
+      "integrity": "sha512-fRHyv6/f542qQqiRGalrfJl/evD39mAvbJLCekPazhiextEatq1Jx1K/i9gSd5NNO0ds03ek0Cbo/4uVKmOBcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "11.1.1",
+        "@chevrotain/types": "11.1.1",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.1.tgz",
+      "integrity": "sha512-Ko/5vPEYy1vn5CbCjjvnSO4U7GgxyGm+dfUZZJIWTlQFkXkyym0jFYrWEU10hyCjrA7rQtiHtBr0EaZqvHFZvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "11.1.1",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.1.tgz",
+      "integrity": "sha512-ctRw1OKSXkOrR8VTvOxrQ5USEc4sNrfwXHa1NuTcR7wre4YbjPcKw+82C2uylg/TEwFRgwLmbhlln4qkmDyteg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.1.tgz",
+      "integrity": "sha512-wb2ToxG8LkgPYnKe9FH8oGn3TMCBdnwiuNC5l5y+CtlaVRbCytU0kbVsk6CGrqTL4ZN4ksJa0TXOYbxpbthtqw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.1.tgz",
+      "integrity": "sha512-71eTYMzYXYSFPrbg/ZwftSaSDld7UYlS8OQa3lNnn9jzNtpFbaReRRyghzqS7rI3CDaorqpPJJcXGHK+FE1TVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
@@ -1332,6 +1391,23 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "mlly": "^1.8.0"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
@@ -1848,6 +1924,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.0.tgz",
+      "integrity": "sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw==",
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2058,7 +2143,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4838,6 +4922,259 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/dompurify": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
@@ -4853,6 +5190,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -5531,7 +5874,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -6219,6 +6561,33 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chevrotain": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.1.tgz",
+      "integrity": "sha512-f0yv5CPKaFxfsPTBzX7vGuim4oIC1/gcS7LUGdBSwl2dU6+FON6LVUksdOo1qJjoUvXNn45urgh8C+0a24pACQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "11.1.1",
+        "@chevrotain/gast": "11.1.1",
+        "@chevrotain/regexp-to-ast": "11.1.1",
+        "@chevrotain/types": "11.1.1",
+        "@chevrotain/utils": "11.1.1",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
+      "peerDependencies": {
+        "chevrotain": "^11.0.0"
+      }
+    },
     "node_modules/chromium-bidi": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
@@ -6335,11 +6704,26 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
@@ -6360,6 +6744,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
       }
     },
     "node_modules/cosmiconfig": {
@@ -6420,6 +6813,507 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
+      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz",
+      "integrity": "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -6490,6 +7384,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -6563,6 +7463,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/dequal": {
@@ -7977,6 +8886,12 @@
       "license": "Standard 'no charge' license: https://gsap.com/standard-license.",
       "peer": true
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -8154,6 +9069,18 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -8209,6 +9136,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -8813,6 +9749,31 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.32",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.32.tgz",
+      "integrity": "sha512-ac0FzkRJlpw4WyH3Zu/OgU9LmPKqjHr6O2BxfSrBt8uJ1BhvH2YK3oJ4ut/K+O+6qQt2MGpdbn0MrffVEnnUDQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8821,6 +9782,28 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/langium": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
+      "integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chevrotain": "~11.1.1",
+        "chevrotain-allstar": "~0.3.1",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -8842,6 +9825,12 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/lenis": {
       "version": "1.3.17",
@@ -9200,6 +10189,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -9281,6 +10276,18 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -9311,6 +10318,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.12.3",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.3.tgz",
+      "integrity": "sha512-wN5ZSgJQIC+CHJut9xaKWsknLxaFBwCPwPkGTSUYrTiHORWvpT8RxGk849HPnpUAQ+/9BPRqYb80jTpearrHzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.1",
+        "@mermaid-js/parser": "^1.0.0",
+        "@types/d3": "^7.4.3",
+        "cytoscape": "^3.29.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.13",
+        "dayjs": "^1.11.18",
+        "dompurify": "^3.2.5",
+        "katex": "^0.16.22",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.2.1",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
       }
     },
     "node_modules/micromatch": {
@@ -9355,6 +10390,18 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT"
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
     },
     "node_modules/motion": {
       "version": "12.33.0",
@@ -9797,6 +10844,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -9839,6 +10892,12 @@
       "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
       "license": "MIT"
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -9866,6 +10925,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -9889,6 +10954,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
       }
     },
     "node_modules/playwright": {
@@ -9936,6 +11012,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -10769,11 +11861,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
+    },
     "node_modules/rope-sequence": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -10798,6 +11908,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -10873,6 +11989,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -11404,6 +12526,12 @@
         }
       }
     },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11532,6 +12660,15 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -11611,6 +12748,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -11817,6 +12963,12 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
     },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -12002,6 +13154,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/vite-compatible-readable-stream": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
@@ -12015,6 +13180,55 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "portfolio",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/amazon-bedrock": "^4.0.63",
+        "@ai-sdk/react": "^3.0.99",
         "@anthropic-ai/sdk": "^0.74.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
@@ -31,6 +33,7 @@
         "@tiptap/extension-youtube": "^3.19.0",
         "@tiptap/react": "^3.19.0",
         "@tiptap/starter-kit": "^3.19.0",
+        "ai": "^6.0.97",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -72,6 +75,106 @@
         "typescript": "^5"
       }
     },
+    "node_modules/@ai-sdk/amazon-bedrock": {
+      "version": "4.0.63",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-4.0.63.tgz",
+      "integrity": "sha512-kNOaIaOXWFZFWbB0xM1l/bQYo7XwTkpdHbrA6n9A2U1c4/DcLF/+Rwc3vZF6MHPVSjoYVG0qxIa7jh39rKftYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/anthropic": "3.0.46",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15",
+        "@smithy/eventstream-codec": "^4.0.1",
+        "@smithy/util-utf8": "^4.0.0",
+        "aws4fetch": "^1.0.20"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.46",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.46.tgz",
+      "integrity": "sha512-zXJPiNHaIiQ6XUqLeSYZ3ZbSzjqt1pNWEUf2hlkXlmmw8IF8KI0ruuGaDwKCExmtuNRf0E4TDxhsc9wRgWTzpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.53.tgz",
+      "integrity": "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
+      "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "3.0.99",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.99.tgz",
+      "integrity": "sha512-xMsp5br4Dpr/3BYq/jrE8q4YLgViU1KHVq8VB0+dzdLJFU3jKA83uoxpbWqzV/edQOBPgGBSb2CgmV5v77rvzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.15",
+        "ai": "6.0.97",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
+      }
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -103,6 +206,82 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
+      "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1874,6 +2053,16 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
@@ -3609,6 +3798,89 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.8.tgz",
+      "integrity": "sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
+      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
@@ -5240,6 +5512,15 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/abs-svg-path": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
@@ -5277,6 +5558,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.97",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.97.tgz",
+      "integrity": "sha512-eZIAcBymwGhBwncRH/v9pillZNMeRCDkc4BwcvwXerXd7sxjVxRis3ZNCNCpP02pVH4NLs81ljm4cElC4vbNcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.53",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -5552,6 +5851,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
     },
     "node_modules/axe-core": {
       "version": "4.11.1",
@@ -7172,6 +7477,15 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -8436,6 +8750,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
@@ -11116,6 +11436,19 @@
       "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
       "license": "ISC"
     },
+    "node_modules/swr": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.0.tgz",
+      "integrity": "sha512-sUlC20T8EOt1pHmDiqueUWMmRRX03W7w5YxovWX7VR2KHEPCTMly85x05vpkP5i6Bu4h44ePSMD9Tc+G2MItFw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
@@ -11179,6 +11512,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiny-inflate": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lenis": "^1.3.17",
     "lowlight": "^3.3.0",
     "lucide-react": "^0.563.0",
+    "mermaid": "^11.12.3",
     "motion": "^12.33.0",
     "next": "16.1.6",
     "next-themes": "^0.4.6",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/amazon-bedrock": "^4.0.63",
+    "@ai-sdk/react": "^3.0.99",
     "@anthropic-ai/sdk": "^0.74.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
@@ -35,6 +37,7 @@
     "@tiptap/extension-youtube": "^3.19.0",
     "@tiptap/react": "^3.19.0",
     "@tiptap/starter-kit": "^3.19.0",
+    "ai": "^6.0.97",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/specs/07-MULTI-AGENT-SYSTEM.md
+++ b/specs/07-MULTI-AGENT-SYSTEM.md
@@ -1,0 +1,531 @@
+# Specification: Multi-Agent Career AI System
+
+## 1. Executive Summary
+
+Transform the existing portfolio admin dashboard into a multi-agent AI workspace using the **Vercel AI SDK** with **Amazon Bedrock** as the AI provider. The system features three distinct AI personas (**Interviewer**, **Architect**, **Resume Tailor**) that share memory asynchronously via Supabase PostgreSQL, plus an **On-Demand Prompt Engineer** with meta-AI optimization. Each agent uses a cost-optimized model from the Bedrock model catalog.
+
+### Provider Strategy
+
+| Layer | Technology | Rationale |
+|-------|-----------|-----------|
+| SDK | `ai` (Vercel AI SDK core) | `useChat()`, tool calling, streaming, structured output |
+| Provider | `@ai-sdk/amazon-bedrock` | Multi-model access (Claude, Llama, Nova) via single provider |
+| Sub-provider | `bedrockAnthropic()` | Claude-specific features: tool calling, cache points, reasoning |
+| Auth | Bedrock API Key (Bearer token) | Single env var: `AWS_BEARER_TOKEN_BEDROCK` |
+
+### Per-Agent Model Selection
+
+Each agent is assigned an optimized model based on its capability requirements:
+
+| Agent | Default Model ID | Why |
+|-------|-----------------|-----|
+| Career Interviewer (Gem 1) | `us.anthropic.claude-sonnet-4-20250514-v1:0` | Tool calling + nuanced multi-turn conversation |
+| Enterprise Architect (Gem 2) | `us.anthropic.claude-sonnet-4-20250514-v1:0` | Creative reasoning + structured Mermaid output |
+| Resume Tailor (Gem 3) | `us.anthropic.claude-sonnet-4-20250514-v1:0` | Large context + structured JSON output |
+| Prompt Optimizer | `us.anthropic.claude-sonnet-4-20250514-v1:0` | One-shot prompt restructuring |
+| Bullet Rewrite / Cliché Detect | `us.anthropic.claude-3-5-haiku-20241022-v1:0` | Simple, fast tasks — lower cost |
+
+> **Model override:** Every agent's model is configurable via the `ai_prompts.model_id` column, allowing runtime model swaps through the Prompt Engineer admin UI without code changes.
+
+### Bedrock Cache Points (Cost Optimization)
+
+For agents with large static context (especially Gem 3's career data dump), use Bedrock cache points to avoid re-processing the same context on every turn:
+
+```typescript
+messages: [{
+  role: 'assistant',
+  content: [{ type: 'text', text: systemPrompt }, { type: 'text', text: careerContext }],
+  providerOptions: { bedrock: { cachePoint: { type: 'default' } } },
+}]
+```
+
+This can reduce input token costs by up to 90% for repeated context.
+
+---
+
+## 2. Core Infrastructure Changes
+
+### 2.1. Vercel AI SDK Migration
+
+**Current State:** Direct `@anthropic-ai/sdk` calls in `src/lib/resume-builder/ai/client.ts` — no streaming, no tool-calling, no structured output.
+
+**Target State:** Vercel AI SDK with `@ai-sdk/amazon-bedrock` provider, enabling `useChat()`, `streamText()`, `generateObject()`, Zod-typed tool definitions, and multi-model routing.
+
+**Tasks:**
+
+1. Install dependencies:
+   ```bash
+   npm install ai @ai-sdk/amazon-bedrock
+   ```
+   > Note: `zod` v4 is already installed. Verify compatibility with `ai` SDK's `tool()` function.
+   > `@aws-sdk/credential-providers` is NOT needed — Bedrock API key uses Bearer token auth.
+
+2. Add Bedrock API key to `.env.local`:
+   ```
+   AWS_BEARER_TOKEN_BEDROCK=your-bedrock-api-key-here
+   ```
+   > Generate a **long-term** API key in the AWS Bedrock console for development.
+
+3. Create new provider module at `src/lib/ai/provider.ts`:
+   ```typescript
+   // Zero-config: auto-reads AWS_BEARER_TOKEN_BEDROCK from env
+   import { bedrock } from '@ai-sdk/amazon-bedrock'
+   export { bedrock }
+   ```
+
+4. Create model registry at `src/lib/ai/models.ts`:
+   ```typescript
+   import { bedrock } from './provider'
+
+   // Available models with metadata for the admin UI
+   export const AVAILABLE_MODELS = {
+     'us.anthropic.claude-sonnet-4-20250514-v1:0': {
+       label: 'Claude Sonnet 4',
+       provider: 'Anthropic',
+       tier: 'premium',
+       capabilities: ['tools', 'streaming', 'vision', 'reasoning'],
+     },
+     'us.anthropic.claude-3-5-sonnet-20241022-v2:0': {
+       label: 'Claude 3.5 Sonnet v2',
+       provider: 'Anthropic',
+       tier: 'standard',
+       capabilities: ['tools', 'streaming', 'vision'],
+     },
+     'us.anthropic.claude-3-5-haiku-20241022-v1:0': {
+       label: 'Claude 3.5 Haiku',
+       provider: 'Anthropic',
+       tier: 'fast',
+       capabilities: ['tools', 'streaming'],
+     },
+     'amazon.nova-pro-v1:0': {
+       label: 'Amazon Nova Pro',
+       provider: 'Amazon',
+       tier: 'standard',
+       capabilities: ['streaming'],
+     },
+     'meta.llama3-70b-instruct-v1:0': {
+       label: 'Llama 3 70B',
+       provider: 'Meta',
+       tier: 'standard',
+       capabilities: ['streaming'],
+     },
+   } as const
+
+   export type ModelId = keyof typeof AVAILABLE_MODELS
+
+   export function getModel(modelId?: string) {
+     const id = modelId ?? 'us.anthropic.claude-sonnet-4-20250514-v1:0'
+     return bedrock(id)
+   }
+
+   export function getModelInfo(modelId: string) {
+     return AVAILABLE_MODELS[modelId as ModelId] ?? null
+   }
+   ```
+
+5. **Do NOT remove** the existing `@anthropic-ai/sdk` client yet — existing services in `services.ts` will be migrated incrementally in later phases.
+
+### 2.2. Shared Agent Chat Component
+
+**Problem:** Building 3 separate chat UIs (Interviewer, Architect, Tailor) will duplicate streaming logic, tool-call rendering, and message persistence.
+
+**Solution:** Create `src/components/agent-chat/` with:
+
+| File | Purpose |
+|------|---------|
+| `agent-chat.tsx` | Core chat shell: `useChat()` hook, message list, input, streaming |
+| `message-bubble.tsx` | Renders user/assistant messages with markdown support |
+| `tool-call-card.tsx` | Renders in-progress and completed tool calls (e.g., "Saving experience...") |
+| `mermaid-block.tsx` | Detects and renders `mermaid` code blocks inline |
+| `json-preview.tsx` | Renders structured JSON output with syntax highlighting |
+
+**Architecture:**
+```typescript
+// Usage pattern for each agent page:
+<AgentChat
+  apiEndpoint="/api/agents/coach"
+  systemPromptSlug="career_interviewer"
+  onToolResult={(toolName, result) => { /* handle UI updates */ }}
+  renderCustomBlock={(block) => { /* mermaid, json, etc. */ }}
+/>
+```
+
+The component uses Vercel AI SDK's `useChat()` hook internally, which handles:
+- Streaming token-by-token rendering
+- Automatic message state management
+- Tool call lifecycle (pending → result)
+- Error states and retry
+
+### 2.3. The "On-Demand Prompt Engineer"
+
+**Current State:** Basic prompt CRUD in `src/app/admin/prompt-engineer/` backed by `ai_prompts` table.
+
+**Target State:** Add "Auto-Perfect" button that uses a meta-AI call to optimize any prompt.
+
+**Tasks:**
+
+1. Add `autoOptimizePrompt` Server Action in `src/app/admin/prompt-engineer/actions.ts`:
+   ```typescript
+   export async function autoOptimizePrompt(draftPrompt: string): Promise<string>
+   ```
+
+2. Use `generateText()` from Vercel AI SDK with this meta-prompt:
+
+   ```xml
+   <role>
+   You are an expert Prompt Engineer specializing in Claude system prompts.
+   </role>
+
+   <task>
+   The user will provide a draft system prompt. Restructure and optimize it for maximum AI compliance.
+   </task>
+
+   <rules>
+   1. Use clear XML tags to separate role, objective, rules, and output_format sections.
+   2. Add explicit constraints for edge cases the draft may have missed.
+   3. Include a "begin by" instruction to anchor the AI's first response.
+   4. Remove ambiguity — replace vague instructions with specific, testable behaviors.
+   5. Preserve the original intent and domain expertise completely.
+   6. Do NOT add placeholder examples — only add examples if the original prompt warrants them.
+   </rules>
+
+   <output_format>
+   Return ONLY the perfected prompt text. No commentary, no markdown wrapping, no explanation.
+   </output_format>
+   ```
+
+3. Wire to UI: Add "Auto-Optimize" button in `prompt-engineer-client.tsx` next to the save button.
+
+---
+
+## 3. The Multi-Agent Ecosystem (The 3 Gems)
+
+### Shared Infrastructure
+
+All 3 agents share:
+
+1. **API Route Pattern:** `src/app/api/agents/[agentName]/route.ts` using Vercel AI SDK's `streamText()` with tool definitions.
+2. **System Prompt Resolution:** Fetch from `ai_prompts` table by slug, with fallback to hardcoded defaults.
+3. **Auth Guard:** All routes verify admin session via `src/lib/admin-auth.ts`.
+4. **Usage Logging:** Wrap `streamText()` calls to log tokens to `ai_usage_log`.
+
+**Tool Definition Pattern:**
+```typescript
+import { tool } from 'ai'
+import { z } from 'zod'
+
+const saveExperience = tool({
+  description: 'Save a work experience entry to the database',
+  parameters: z.object({
+    jobTitle: z.string(),
+    company: z.string(),
+    startDate: z.string(),
+    endDate: z.string().nullable(),
+    techStack: z.array(z.string()),
+    bullets: z.array(z.string().min(10).max(200)),
+  }),
+  execute: async (params) => {
+    // Supabase INSERT
+  },
+})
+```
+
+---
+
+### GEM 1: The Career Interviewer (`career-coach`)
+
+**Goal:** Iteratively interview the user and autonomously save structured career data to the database via tool calls.
+
+**UI:** Enhance `src/app/admin/resume-builder/career-coach/[id]/chat-interface.tsx` to use `<AgentChat>`.
+
+**API Route:** Refactor `src/app/api/resume-builder/coach/route.ts` → `src/app/api/agents/coach/route.ts`
+
+**Vercel AI SDK Tools:**
+
+| Tool Name | Parameters (Zod) | DB Action |
+|-----------|-----------------|-----------|
+| `save_work_experience` | `{ jobTitle, company, startDate, endDate, location, bullets[] }` | INSERT into `resume_work_experiences` + `resume_achievements` |
+| `save_project` | `{ name, description, url, techStack[], bullets[] }` | INSERT into `resume_projects` + `resume_achievements` |
+| `save_skill_category` | `{ categoryName, skills[] }` | UPSERT into `resume_skill_categories` |
+| `update_summary` | `{ summaryText }` | UPSERT into `resume_summaries` |
+
+**Context Injection:** On session start, fetch existing resume data and inject as XML context block:
+```xml
+<existing_career_data>
+  <work_experiences>...</work_experiences>
+  <projects>...</projects>
+  <skills>...</skills>
+</existing_career_data>
+```
+
+**System Prompt** (slug: `career_interviewer`, seed into `ai_prompts`):
+
+```xml
+<role>
+You are an elite Career Coach and Executive Hiring Manager with 15+ years of experience
+placing candidates at FAANG, top startups, and Fortune 500 companies.
+</role>
+
+<objective>
+Interview me iteratively to build a comprehensive repository of my career directly into
+the database. Your goal is to extract maximum-impact career data that produces
+ATS-optimized, executive-quality resume content.
+</objective>
+
+<rules>
+1. ONE AT A TIME: Interview me about ONE company, role, or project at a time. Never ask
+   more than 2 questions per message.
+2. ADAPTIVE PROBING: Before each question, silently assess what's missing from the 4
+   impact categories:
+   - Scale (users, revenue, team size, data volume)
+   - Speed (time saved, delivery acceleration, latency reduction)
+   - Quality (error reduction, uptime improvement, test coverage)
+   - Cost (infrastructure savings, headcount efficiency, budget optimization)
+3. PUSH BACK: If I give vague answers like "I improved performance," demand specifics:
+   "What was the before/after metric? What tools did you use? How many users were affected?"
+4. XYZ FORMULA: Transform all achievements into the XYZ format before saving:
+   "Accomplished [X impact] as measured by [Y metric] by doing [Z action]"
+5. AUTONOMOUS SAVING: Once you have sufficient structured data for a role/project,
+   trigger the appropriate save tool WITHOUT asking permission. Confirm what you saved
+   after the fact.
+6. DEDUPLICATION: Check the existing_career_data context to avoid saving duplicate entries.
+</rules>
+
+Begin every new chat by asking which company or project we are documenting today.
+```
+
+---
+
+### GEM 2: The Enterprise Architect (`architect`)
+
+**Goal:** Brainstorm system designs and output renderable Mermaid.js architecture diagrams.
+
+**UI:** Create `src/app/admin/architect/page.tsx` with `<AgentChat>` + Mermaid rendering.
+
+**API Route:** `src/app/api/agents/architect/route.ts`
+
+**Mermaid Rendering Strategy:**
+- Use `mermaid` library directly (lighter than `react-mermaid2`)
+- Install: `npm install mermaid`
+- The `<AgentChat>` component's `mermaid-block.tsx` will:
+  1. Detect ` ```mermaid ` code fences in streamed markdown
+  2. After streaming completes for that block, render via `mermaid.render()`
+  3. Display raw code toggle for copy/paste
+
+**Context Injection:** Fetch user's skill categories from `resume_skill_categories` to inform technology recommendations.
+
+**System Prompt** (slug: `enterprise_architect`, seed into `ai_prompts`):
+
+```xml
+<role>
+You are a Veteran Systems Engineering Agent and Enterprise Architect with 20+ years of
+experience designing highly scalable, distributed systems across cloud platforms
+(AWS, GCP, Azure).
+</role>
+
+<objective>
+Conceptualize enterprise-grade architectures based on my descriptions and translate them
+into visual Mermaid.js diagrams.
+</objective>
+
+<rules>
+1. ANALYZE BEFORE DIAGRAMMING: When I describe a system, evaluate for:
+   - Single points of failure
+   - Scalability bottlenecks
+   - Security gaps (authentication, encryption, network isolation)
+   - Cost optimization opportunities
+2. ADVISE FIRST: Proactively suggest 1-2 high-impact improvements. Wait for my approval
+   before finalizing the diagram.
+3. MERMAID ONLY: Output exclusively in mermaid code blocks. No PlantUML or ASCII art.
+4. DIAGRAM QUALITY:
+   - Always use subgraph to group logical components (VPCs, services, data layers)
+   - Label all edges with protocols: -->|HTTPS|, -->|gRPC|, -->|WebSocket|, -->|SQL|
+   - Use consistent node shapes: databases as [(db)], services as [service],
+     queues as {{queue}}
+   - Ensure zero syntax errors — validate mentally before outputting.
+5. ITERATE: After presenting a diagram, ask if I want to zoom into a specific component,
+   add failure modes, or explore alternatives.
+</rules>
+
+<output_format>
+All architecture outputs must be in mermaid code blocks. Accompany each diagram with a
+brief (2-3 sentence) explanation of the key design decisions.
+</output_format>
+
+Begin every new chat by asking what system or architecture we are designing today.
+```
+
+---
+
+### GEM 3: The Resume Tailor (`jd-analyzer`)
+
+**Goal:** Map a target Job Description against the user's entire career history to generate a fully tailored resume JSON.
+
+**UI:** Enhance `src/app/admin/resume-builder/jd-analyzer/jd-analyzer-client.tsx` to use `<AgentChat>` with JSON preview panel.
+
+**API Route:** Refactor `src/app/api/resume-builder/ai/route.ts` (analyze-jd action) → `src/app/api/agents/tailor/route.ts`
+
+**RAG Workflow with Token Budgeting:**
+
+The full portfolio JSON dump can exceed 50K tokens for extensive careers. Strategy:
+
+1. **Fetch** all career data via `getPortfolioData()` (existing function).
+2. **Prioritize:** Sort experiences by recency. For each experience, include full bullets. For experiences older than 10 years, include only company/title/dates.
+3. **Budget:** Estimate tokens (~4 chars/token). If context exceeds 30K tokens, truncate oldest entries first.
+4. **Inject** as XML context block alongside the JD.
+
+**Vercel AI SDK Tools:**
+
+| Tool Name | Parameters (Zod) | Action |
+|-----------|-----------------|--------|
+| `analyze_jd` | `{ rawText }` → returns `JDAnalysis` | Extract skills, requirements, experience level |
+| `generate_tailored_bullets` | `{ experienceId, count }` → returns `string[]` | Generate bullets for specific role |
+| `generate_full_resume` | `{ templateId }` → returns `ResumeWithRelations` (partial) | Full resume JSON matching existing type |
+
+**Structured Output:** Use `generateObject()` with Zod schema matching `ResumeWithRelations` for the `/full` command. This eliminates JSON parsing errors entirely.
+
+**System Prompt** (slug: `resume_tailor`, seed into `ai_prompts`):
+
+```xml
+<role>
+You are an Executive Resume Writer and Career Strategist with expertise in ATS
+optimization. You have full access to the user's factual career history via the
+provided context.
+</role>
+
+<objective>
+Tailor existing experience to specific job descriptions, ensuring high ATS match rates
+without fabricating information.
+</objective>
+
+<rules>
+1. STRICT FACTUAL ACCURACY: Use ONLY data from the provided career context. Never
+   hallucinate, invent, or exaggerate experience. If the user lacks a required skill,
+   flag it as a gap — do not fabricate it.
+2. VOCABULARY MIRRORING: Cross-reference existing bullet points against the target JD.
+   Rewrite bullets to mirror the exact terminology and keywords from the JD while
+   preserving factual accuracy.
+3. XYZ FORMULA: All bullets must follow: "Accomplished [X] as measured by [Y] by doing [Z]"
+4. PRIORITIZATION: Lead with the most JD-relevant experiences. Reorder sections to
+   front-load matching skills.
+5. STRUCTURED OUTPUT: When generating full resumes or bullet sets, always use the
+   provided tool calls. Never output raw JSON in chat text.
+</rules>
+
+<commands>
+- /analyze [paste JD]: Extract top 5 technical skills, top 3 soft skills, and provide a
+  match rating (0-100%) against the user's profile.
+- /bullets: Generate 5-7 tailored bullet points for the most relevant roles.
+- /full: Generate a complete tailored resume using the generate_full_resume tool.
+- /gap: Identify missing skills and provide interview talking points to address them.
+</commands>
+
+Begin every new chat by asking the user to paste the target Job Description.
+```
+
+---
+
+## 4. Database & Schema Changes
+
+### 4.1. Migration: Extend `ai_prompts` for Agent Personas
+
+Create `supabase/migrations/YYYYMMDD_agent_personas.sql`:
+
+```sql
+-- Add persona_name column to identify agent-specific prompts
+ALTER TABLE ai_prompts ADD COLUMN IF NOT EXISTS persona_name TEXT;
+
+-- Add model_id column for explicit model binding
+ALTER TABLE ai_prompts ADD COLUMN IF NOT EXISTS model_id TEXT;
+
+-- Extend category enum to include 'agent' type
+-- (category is TEXT, no enum change needed — just convention)
+
+-- Index for fast persona lookups
+CREATE INDEX IF NOT EXISTS idx_ai_prompts_persona
+  ON ai_prompts(persona_name) WHERE persona_name IS NOT NULL;
+```
+
+### 4.2. Seed Agent Prompts
+
+Insert the 3 agent system prompts + the meta-prompt into `ai_prompts` via a migration or seed script:
+
+| slug | persona_name | category |
+|------|-------------|----------|
+| `career_interviewer` | `interviewer` | `agent` |
+| `enterprise_architect` | `architect` | `agent` |
+| `resume_tailor` | `tailor` | `agent` |
+| `meta_prompt_optimizer` | `prompt_engineer` | `agent` |
+
+### 4.3. Verify Existing Tables
+
+The following tables already exist and require **no changes**:
+- `resume_work_experiences`, `resume_achievements` — used by Gem 1 tool calls
+- `resume_projects` — used by Gem 1 tool calls
+- `resume_skill_categories` — used by Gem 1 & 2
+- `job_descriptions` — used by Gem 3
+- `career_coach_sessions` — used by Gem 1 (message persistence)
+- `ai_usage_log` — used by all agents
+
+---
+
+## 5. Security & Access Control
+
+1. **All agent API routes** (`/api/agents/*`) must verify admin session via `src/lib/admin-auth.ts`.
+2. **Anthropic API key** stored in `.env.local`, never exposed to client bundle.
+3. **Tool execution** happens server-side only — the client sees tool call results, never executes them.
+4. **Rate limiting** (future): Consider adding per-user rate limits on agent API routes.
+
+---
+
+## 6. Error Handling & Resilience
+
+| Scenario | Strategy |
+|----------|----------|
+| LLM timeout (>30s) | Vercel AI SDK handles via `maxDuration` on route config; show "Taking longer than expected..." in UI |
+| Invalid tool parameters | Zod validation rejects before execution; return error to LLM for self-correction |
+| Tool execution failure (DB error) | Return error message to LLM; it should inform the user and retry |
+| JSON parse failure | Eliminated by `generateObject()` with Zod schemas |
+| Token limit exceeded | Pre-flight token estimation; truncate context before sending |
+| API key missing | Graceful degradation: show "AI features unavailable" banner |
+
+---
+
+## 7. Implementation Phases
+
+### Phase 1: Foundation (SDK Migration)
+- Install `ai`, `@ai-sdk/anthropic`
+- Create `src/lib/ai/provider.ts` and `src/lib/ai/models.ts`
+- Verify Vercel AI SDK works with a simple test route
+- **Does NOT remove** existing `@anthropic-ai/sdk` usage
+
+### Phase 2: Shared Components
+- Build `src/components/agent-chat/` (AgentChat, MessageBubble, ToolCallCard)
+- Install `mermaid`, build MermaidBlock component
+- Build JsonPreview component
+
+### Phase 3: Prompt Engineer Enhancement
+- Add `autoOptimizePrompt` server action with meta-prompt
+- Wire to prompt-engineer UI
+- Run migration: add `persona_name`, `model_id` columns
+- Seed 3 agent prompts + meta-prompt into DB
+
+### Phase 4: Gem 1 — The Career Interviewer
+- Create `/api/agents/coach/route.ts` with `streamText()` + tool definitions
+- Define Zod tool schemas for `save_work_experience`, `save_project`, `save_skill_category`
+- Implement tool execution functions (Supabase INSERTs)
+- Refactor career-coach UI to use `<AgentChat>`
+- Test: full interview flow → data appears in DB
+
+### Phase 5: Gem 2 — The Enterprise Architect
+- Create `src/app/admin/architect/page.tsx`
+- Create `/api/agents/architect/route.ts` with `streamText()`
+- Integrate Mermaid rendering in chat
+- Test: describe a system → see rendered diagram
+
+### Phase 6: Gem 3 — The Resume Tailor
+- Create `/api/agents/tailor/route.ts` with `streamText()` + tools
+- Implement RAG context builder with token budgeting
+- Define `generate_full_resume` tool with `ResumeWithRelations` Zod schema
+- Refactor JD analyzer UI to use `<AgentChat>` + JSON preview
+- Test: paste JD → get tailored resume JSON → preview renders correctly

--- a/src/app/(public)/blog/[slug]/page.tsx
+++ b/src/app/(public)/blog/[slug]/page.tsx
@@ -99,7 +99,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
               height={480}
               className="h-full w-full object-cover"
               priority
-              unoptimized
+              sizes="(max-width: 1200px) 100vw, 1200px"
             />
           </div>
         </div>

--- a/src/app/(public)/blog/blog-listing.tsx
+++ b/src/app/(public)/blog/blog-listing.tsx
@@ -51,7 +51,7 @@ function PostCard({ post }: { post: Post }) {
               width={640}
               height={320}
               className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-              unoptimized
+              sizes="(max-width: 768px) 100vw, 50vw"
             />
           </div>
         )}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,14 +1,29 @@
 import type { Metadata } from "next"
+import dynamic from "next/dynamic"
 import { Hero } from "@/components/sections/Hero"
 import { About } from "@/components/sections/About"
-import { Projects } from "@/components/sections/Projects"
-import { Skills } from "@/components/sections/Skills"
-import { Experience } from "@/components/sections/Experience"
-import { Credentials } from "@/components/sections/Credentials"
-import { Ventures } from "@/components/sections/Ventures"
-import { Blog } from "@/components/sections/Blog"
-import { Contact } from "@/components/sections/Contact"
 import { JsonLd } from "@/components/JsonLd"
+
+// Dynamically import below-the-fold sections to reduce initial JS parse (TBT)
+const Ventures = dynamic(() =>
+  import("@/components/sections/Ventures").then((m) => ({ default: m.Ventures })),
+)
+const Projects = dynamic(() =>
+  import("@/components/sections/Projects").then((m) => ({ default: m.Projects })),
+)
+const Skills = dynamic(() =>
+  import("@/components/sections/Skills").then((m) => ({ default: m.Skills })),
+)
+const Experience = dynamic(() =>
+  import("@/components/sections/Experience").then((m) => ({ default: m.Experience })),
+)
+const Credentials = dynamic(() =>
+  import("@/components/sections/Credentials").then((m) => ({ default: m.Credentials })),
+)
+const Blog = dynamic(() => import("@/components/sections/Blog").then((m) => ({ default: m.Blog })))
+const Contact = dynamic(() =>
+  import("@/components/sections/Contact").then((m) => ({ default: m.Contact })),
+)
 import { getCachedSiteConfig } from "@/lib/seo"
 import { personAndWebsiteJsonLd } from "@/lib/json-ld"
 import {

--- a/src/app/admin/admin-sidebar.tsx
+++ b/src/app/admin/admin-sidebar.tsx
@@ -27,6 +27,7 @@ import {
   Search,
   Bot,
   Wand2,
+  Blocks,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -112,6 +113,11 @@ const navItems: NavItem[] = [
     href: "/admin/resume-builder/career-coach",
     label: "Career Coach",
     icon: Bot,
+  },
+  {
+    href: "/admin/architect",
+    label: "Architect",
+    icon: Blocks,
   },
   {
     href: "/admin/prompt-engineer",

--- a/src/app/admin/admin-sidebar.tsx
+++ b/src/app/admin/admin-sidebar.tsx
@@ -28,6 +28,7 @@ import {
   Bot,
   Wand2,
   Blocks,
+  Scissors,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -113,6 +114,11 @@ const navItems: NavItem[] = [
     href: "/admin/resume-builder/career-coach",
     label: "Career Coach",
     icon: Bot,
+  },
+  {
+    href: "/admin/resume-builder/tailor",
+    label: "Resume Tailor",
+    icon: Scissors,
   },
   {
     href: "/admin/architect",

--- a/src/app/admin/admin-sidebar.tsx
+++ b/src/app/admin/admin-sidebar.tsx
@@ -114,6 +114,13 @@ const navItems: NavItem[] = [
     href: "/admin/resume-builder/career-coach",
     label: "Career Coach",
     icon: Bot,
+    children: [
+      { hash: "general", label: "General Advice" },
+      { hash: "experience_builder", label: "Experience Builder" },
+      { hash: "project_builder", label: "Project Builder" },
+      { hash: "interview_prep", label: "Interview Prep" },
+      { hash: "career_narrative", label: "Career Narrative" },
+    ],
   },
   {
     href: "/admin/resume-builder/tailor",
@@ -198,9 +205,21 @@ export function AdminSidebar({ unreadCount = 0 }: AdminSidebarProps) {
   const isPageActive = useCallback(
     (href: string) => {
       if (href === "/admin") return pathname === "/admin"
-      // Exact match or match with trailing slash/segment to prevent
-      // /admin/resume matching /admin/resume-builder
-      return pathname === href || pathname.startsWith(href + "/")
+      const matches = pathname === href || pathname.startsWith(href + "/")
+      if (!matches) return false
+      // Don't highlight if a more specific nav item also matches
+      // e.g. /admin/resume-builder shouldn't highlight when /admin/resume-builder/career-coach matches
+      for (const other of navItems) {
+        if (
+          other.href !== href &&
+          other.href.length > href.length &&
+          other.href.startsWith(href + "/") &&
+          (pathname === other.href || pathname.startsWith(other.href + "/"))
+        ) {
+          return false
+        }
+      }
+      return true
     },
     [pathname],
   )
@@ -235,7 +254,7 @@ export function AdminSidebar({ unreadCount = 0 }: AdminSidebarProps) {
           </Badge>
         </Link>
       </div>
-      <ScrollArea className="flex-1 px-3 py-4">
+      <ScrollArea className="flex-1 overflow-y-auto px-3 py-4" type="auto">
         <nav aria-label="Admin navigation" className="flex flex-col gap-0.5">
           {navItems.map((item) => {
             const active = isPageActive(item.href)

--- a/src/app/admin/architect/architect-client.tsx
+++ b/src/app/admin/architect/architect-client.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { AgentChat } from "@/components/agent-chat"
+
+export function ArchitectClient() {
+  return (
+    <div style={{ height: "calc(100vh - 56px)" }}>
+      <AgentChat
+        apiEndpoint="/api/agents/architect"
+        placeholder="Describe the system you want to design..."
+        emptyMessage="I'm your Enterprise Architect. Describe a system and I'll design a scalable architecture with Mermaid.js diagrams."
+      />
+    </div>
+  )
+}

--- a/src/app/admin/architect/page.tsx
+++ b/src/app/admin/architect/page.tsx
@@ -1,0 +1,11 @@
+import { AdminHeader } from "../admin-header"
+import { ArchitectClient } from "./architect-client"
+
+export default function ArchitectPage() {
+  return (
+    <>
+      <AdminHeader title="Enterprise Architect" />
+      <ArchitectClient />
+    </>
+  )
+}

--- a/src/app/admin/prompt-engineer/actions.ts
+++ b/src/app/admin/prompt-engineer/actions.ts
@@ -2,7 +2,9 @@
 
 import { createClient } from "@/lib/supabase/server"
 import { revalidatePath } from "next/cache"
+import { generateText } from "ai"
 import { getAnthropicClient } from "@/lib/resume-builder/ai/client"
+import { getModel } from "@/lib/ai/models"
 import type { AIPrompt } from "@/types/ai-prompts"
 
 export async function listPrompts(): Promise<AIPrompt[]> {
@@ -96,4 +98,52 @@ export async function testPrompt(
 
   const textBlock = response.content.find((b) => b.type === "text")
   return textBlock?.text?.trim() ?? ""
+}
+
+const META_PROMPT_SYSTEM = `<role>
+You are an expert Prompt Engineer specializing in Claude system prompts.
+</role>
+
+<task>
+The user will provide a draft system prompt. Restructure and optimize it for maximum AI compliance.
+</task>
+
+<rules>
+1. Use clear XML tags to separate role, objective, rules, and output_format sections.
+2. Add explicit constraints for edge cases the draft may have missed.
+3. Include a "begin by" instruction to anchor the AI's first response.
+4. Remove ambiguity — replace vague instructions with specific, testable behaviors.
+5. Preserve the original intent and domain expertise completely.
+6. Do NOT add placeholder examples — only add examples if the original prompt warrants them.
+</rules>
+
+<output_format>
+Return ONLY the perfected prompt text. No commentary, no markdown wrapping, no explanation.
+</output_format>`
+
+/** Use a meta-AI call to optimize a draft system prompt */
+export async function autoOptimizePrompt(draftPrompt: string): Promise<string> {
+  if (!draftPrompt.trim()) {
+    throw new Error("Draft prompt cannot be empty")
+  }
+
+  // Fetch the meta_prompt_optimizer from DB (if customized), fall back to hardcoded
+  const supabase = await createClient()
+  const { data: metaPrompt } = await supabase
+    .from("ai_prompts")
+    .select("system_prompt, model_id")
+    .eq("slug", "meta_prompt_optimizer")
+    .single()
+
+  const systemPrompt = metaPrompt?.system_prompt ?? META_PROMPT_SYSTEM
+  const modelId = metaPrompt?.model_id ?? undefined
+
+  const { text } = await generateText({
+    model: getModel(modelId),
+    system: systemPrompt,
+    prompt: draftPrompt,
+    maxOutputTokens: 4096,
+  })
+
+  return text.trim()
 }

--- a/src/app/admin/prompt-engineer/prompt-engineer-client.tsx
+++ b/src/app/admin/prompt-engineer/prompt-engineer-client.tsx
@@ -28,15 +28,17 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
 import { toast } from "sonner"
-import { createPrompt, updatePrompt, deletePrompt, testPrompt } from "./actions"
+import { createPrompt, updatePrompt, deletePrompt, testPrompt, autoOptimizePrompt } from "./actions"
+import { AVAILABLE_MODELS } from "@/lib/ai/models"
 import type { AIPrompt } from "@/types/ai-prompts"
 
-const categories = ["bullet", "summary", "description", "general"] as const
+const categories = ["bullet", "summary", "description", "general", "agent"] as const
 const categoryLabels: Record<string, string> = {
   bullet: "Bullet Points",
   summary: "Summary",
   description: "Descriptions",
   general: "General",
+  agent: "AI Agents",
 }
 
 interface Props {
@@ -206,6 +208,9 @@ function PromptEditor({
     max_tokens: prompt.max_tokens,
   })
 
+  // Auto-optimize state
+  const [isOptimizing, setIsOptimizing] = useState(false)
+
   // Test panel state
   const [testVars, setTestVars] = useState("")
   const [testOutput, setTestOutput] = useState("")
@@ -257,6 +262,23 @@ function PromptEditor({
         setTestOutput(`Error: ${err instanceof Error ? err.message : String(err)}`)
       })
       .finally(() => setIsTesting(false))
+  }
+
+  async function handleAutoOptimize() {
+    if (!form.system_prompt.trim()) {
+      toast.error("System prompt is empty — nothing to optimize")
+      return
+    }
+    setIsOptimizing(true)
+    try {
+      const optimized = await autoOptimizePrompt(form.system_prompt)
+      handleChange("system_prompt", optimized)
+      toast.success("System prompt optimized")
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Optimization failed")
+    } finally {
+      setIsOptimizing(false)
+    }
   }
 
   // Extract variables from user_prompt_template
@@ -312,7 +334,23 @@ function PromptEditor({
 
       {/* Prompts */}
       <div className="space-y-2">
-        <Label className="text-xs">System Prompt</Label>
+        <div className="flex items-center justify-between">
+          <Label className="text-xs">System Prompt</Label>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleAutoOptimize}
+            disabled={isOptimizing || isPending}
+            className="h-7 text-xs"
+          >
+            {isOptimizing ? (
+              <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
+            ) : (
+              <Sparkles className="mr-1.5 h-3 w-3" />
+            )}
+            {isOptimizing ? "Optimizing..." : "Auto-Optimize"}
+          </Button>
+        </div>
         <Textarea
           value={form.system_prompt}
           onChange={(e) => handleChange("system_prompt", e.target.value)}
@@ -351,8 +389,15 @@ function PromptEditor({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="claude-sonnet-4-6">claude-sonnet-4-6</SelectItem>
-              <SelectItem value="claude-haiku-4-5">claude-haiku-4-5</SelectItem>
+              {/* Legacy Anthropic direct models (for existing prompts) */}
+              <SelectItem value="claude-sonnet-4-6">claude-sonnet-4-6 (Legacy)</SelectItem>
+              <SelectItem value="claude-haiku-4-5">claude-haiku-4-5 (Legacy)</SelectItem>
+              {/* Bedrock models */}
+              {Object.entries(AVAILABLE_MODELS).map(([id, info]) => (
+                <SelectItem key={id} value={id}>
+                  {info.label} ({info.tier})
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>

--- a/src/app/admin/resume-builder/career-coach/[id]/chat-interface.tsx
+++ b/src/app/admin/resume-builder/career-coach/[id]/chat-interface.tsx
@@ -1,15 +1,14 @@
 "use client"
 
-import { useState, useRef, useEffect, useCallback } from "react"
+import { useState, useCallback } from "react"
 import Link from "next/link"
 import {
   ArrowLeft,
-  Send,
-  MessageSquare,
   Briefcase,
   FolderKanban,
   Target,
   BookOpen,
+  MessageSquare,
   FileText,
   X,
   Copy,
@@ -17,7 +16,6 @@ import {
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { Textarea } from "@/components/ui/textarea"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import {
@@ -28,13 +26,9 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { toast } from "sonner"
-import { updateCoachSessionMessages, updateCoachSessionContent } from "../actions"
-import type {
-  CareerCoachSession,
-  CoachMessage,
-  CoachSessionType,
-  Resume,
-} from "@/types/resume-builder"
+import { AgentChat } from "@/components/agent-chat"
+import { updateCoachSessionMessages } from "../actions"
+import type { CareerCoachSession, CoachSessionType, Resume } from "@/types/resume-builder"
 
 // ===== Constants =====
 
@@ -47,69 +41,9 @@ const SESSION_TYPE_CONFIG: Record<CoachSessionType, { label: string; icon: typeo
     career_narrative: { label: "Career Narrative", icon: BookOpen },
   }
 
-// ===== Helper Functions =====
-
-function formatTimestamp(timestamp: string): string {
-  return new Date(timestamp).toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-  })
-}
-
-function renderMessageContent(content: string): React.ReactNode[] {
-  return content.split("\n").map((line, i) => {
-    if (line.trim() === "") {
-      return <br key={i} />
-    }
-
-    const parts = line.split(/(\*\*.*?\*\*)/g)
-    const rendered = parts.map((part, j) => {
-      if (part.startsWith("**") && part.endsWith("**")) {
-        return <strong key={j}>{part.slice(2, -2)}</strong>
-      }
-      return part
-    })
-
-    return (
-      <p key={i} className="mb-1 last:mb-0">
-        {rendered}
-      </p>
-    )
-  })
-}
-
-function extractBulletPoints(messages: CoachMessage[]): string[] {
-  const bullets: string[] = []
-  for (const msg of messages) {
-    if (msg.role !== "assistant") continue
-    const lines = msg.content.split("\n")
-    for (const line of lines) {
-      const trimmed = line.trim()
-      if ((trimmed.startsWith("- ") || trimmed.startsWith("* ")) && trimmed.length > 20) {
-        bullets.push(trimmed.slice(2))
-      }
-    }
-  }
-  return bullets
-}
-
 // ===== Sub-Components =====
 
-function LoadingDots() {
-  return (
-    <div className="flex items-center gap-1 px-4 py-3">
-      <span className="bg-muted-foreground/60 h-2 w-2 animate-bounce rounded-full [animation-delay:0ms]" />
-      <span className="bg-muted-foreground/60 h-2 w-2 animate-bounce rounded-full [animation-delay:150ms]" />
-      <span className="bg-muted-foreground/60 h-2 w-2 animate-bounce rounded-full [animation-delay:300ms]" />
-    </div>
-  )
-}
-
-interface BulletItemProps {
-  text: string
-}
-
-function BulletItem({ text }: BulletItemProps) {
+function BulletItem({ text }: { text: string }) {
   const [copied, setCopied] = useState(false)
 
   function handleCopy() {
@@ -133,40 +67,6 @@ function BulletItem({ text }: BulletItemProps) {
   )
 }
 
-interface GeneratedContentPanelProps {
-  sessionType: CoachSessionType
-  bullets: string[]
-}
-
-function GeneratedContentPanel({ sessionType, bullets }: GeneratedContentPanelProps) {
-  const title =
-    sessionType === "experience_builder" ? "Generated Bullets" : "Generated Descriptions"
-
-  if (bullets.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center p-6 text-center">
-        <FileText className="text-muted-foreground mb-2 h-8 w-8" />
-        <p className="text-muted-foreground text-sm">
-          {sessionType === "experience_builder"
-            ? "Achievement bullet points will appear here as the coach generates them."
-            : "Project descriptions will appear here as the coach generates them."}
-        </p>
-      </div>
-    )
-  }
-
-  return (
-    <div className="p-4">
-      <h3 className="mb-3 text-sm font-semibold">{title}</h3>
-      <div className="space-y-2">
-        {bullets.map((bullet, i) => (
-          <BulletItem key={i} text={bullet} />
-        ))}
-      </div>
-    </div>
-  )
-}
-
 // ===== Main Component =====
 
 interface ChatInterfaceProps {
@@ -175,107 +75,38 @@ interface ChatInterfaceProps {
 }
 
 export function ChatInterface({ session, resumes }: ChatInterfaceProps) {
-  const [messages, setMessages] = useState<CoachMessage[]>(session.messages)
-  const [input, setInput] = useState("")
-  const [isLoading, setIsLoading] = useState(false)
-  const [selectedResumeId, setSelectedResumeId] = useState<string>("")
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const [selectedResumeId, setSelectedResumeId] = useState<string>(resumes[0]?.id ?? "")
+  const [savedItems, setSavedItems] = useState<string[]>([])
+
+  const config = SESSION_TYPE_CONFIG[session.session_type]
+  const Icon = config.icon
 
   const hasSidebar =
     session.session_type === "experience_builder" || session.session_type === "project_builder"
 
-  const config = SESSION_TYPE_CONFIG[session.session_type]
-  const Icon = config.icon
-  const generatedBullets = extractBulletPoints(messages)
-
-  const scrollToBottom = useCallback(() => {
-    if (!scrollRef.current) return
-    const scrollContainer = scrollRef.current.querySelector("[data-radix-scroll-area-viewport]")
-    if (scrollContainer) {
-      scrollContainer.scrollTop = scrollContainer.scrollHeight
+  // Track tool results for the sidebar
+  const handleToolResult = useCallback((toolName: string, result: unknown) => {
+    const r = result as { success?: boolean; message?: string }
+    if (r?.success && r?.message) {
+      setSavedItems((prev) => [...prev, r.message!])
+      toast.success(r.message)
     }
   }, [])
 
-  useEffect(() => {
-    scrollToBottom()
-  }, [messages, isLoading, scrollToBottom])
-
-  async function handleSend() {
-    const trimmed = input.trim()
-    if (!trimmed || isLoading) return
-
-    const userMessage: CoachMessage = {
-      role: "user",
-      content: trimmed,
-      timestamp: new Date().toISOString(),
-    }
-
-    const updatedMessages = [...messages, userMessage]
-    setMessages(updatedMessages)
-    setInput("")
-    setIsLoading(true)
-
-    // Resize textarea back to default
-    if (textareaRef.current) {
-      textareaRef.current.style.height = "auto"
-    }
-
-    try {
-      const response = await fetch("/api/resume-builder/coach", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sessionId: session.id,
-          sessionType: session.session_type,
-          messages: updatedMessages.map((m) => ({
-            role: m.role,
-            content: m.content,
-          })),
-          resumeId: selectedResumeId || undefined,
-        }),
-      })
-
-      if (!response.ok) {
-        const errorData = await response.json()
-        throw new Error(errorData.error ?? "Failed to get response")
-      }
-
-      const data = await response.json()
-      const assistantMessage: CoachMessage = {
-        role: "assistant",
-        content: data.response,
+  // Persist messages to DB
+  const handleMessagesChange = useCallback(
+    (messages: Array<{ role: string; content: string }>) => {
+      const coachMessages = messages.map((m) => ({
+        role: m.role as "user" | "assistant",
+        content: m.content,
         timestamp: new Date().toISOString(),
-      }
-
-      const finalMessages = [...updatedMessages, assistantMessage]
-      setMessages(finalMessages)
-
-      // Persist messages to database
-      await updateCoachSessionMessages(session.id, finalMessages)
-
-      // Update generated content if this is a builder session
-      if (hasSidebar) {
-        const bullets = extractBulletPoints(finalMessages)
-        if (bullets.length > 0) {
-          await updateCoachSessionContent(session.id, { bullets })
-        }
-      }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to send message")
-      // Remove the optimistic user message on failure
-      setMessages(messages)
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault()
-      handleSend()
-    }
-  }
+      }))
+      updateCoachSessionMessages(session.id, coachMessages).catch(() => {
+        // Silent persistence failure — messages are still in UI state
+      })
+    },
+    [session.id],
+  )
 
   const selectedResume = resumes.find((r) => r.id === selectedResumeId)
 
@@ -313,7 +144,7 @@ export function ChatInterface({ session, resumes }: ChatInterfaceProps) {
             )}
             <Select value={selectedResumeId} onValueChange={setSelectedResumeId}>
               <SelectTrigger className="w-48">
-                <SelectValue placeholder="Add resume context" />
+                <SelectValue placeholder="Select resume" />
               </SelectTrigger>
               <SelectContent>
                 {resumes.map((resume) => (
@@ -326,77 +157,15 @@ export function ChatInterface({ session, resumes }: ChatInterfaceProps) {
           </div>
         </div>
 
-        {/* Messages */}
-        <ScrollArea ref={scrollRef} className="flex-1">
-          <div className="mx-auto max-w-3xl space-y-4 p-4">
-            {messages.length === 0 && (
-              <div className="flex flex-col items-center justify-center py-20 text-center">
-                <Icon className="text-muted-foreground mb-4 h-12 w-12" />
-                <h3 className="mb-2 text-lg font-semibold">{config.label}</h3>
-                <p className="text-muted-foreground max-w-md text-sm">
-                  {getWelcomeMessage(session.session_type)}
-                </p>
-              </div>
-            )}
-
-            {messages.map((msg, i) => (
-              <div
-                key={i}
-                className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
-              >
-                <div
-                  className={`max-w-[80%] rounded-2xl px-4 py-2.5 ${
-                    msg.role === "user" ? "bg-primary text-primary-foreground" : "bg-muted"
-                  }`}
-                >
-                  <div className="text-sm leading-relaxed">{renderMessageContent(msg.content)}</div>
-                  <div
-                    className={`mt-1 text-[10px] ${
-                      msg.role === "user" ? "text-primary-foreground/60" : "text-muted-foreground"
-                    }`}
-                  >
-                    {formatTimestamp(msg.timestamp)}
-                  </div>
-                </div>
-              </div>
-            ))}
-
-            {isLoading && (
-              <div className="flex justify-start">
-                <div className="bg-muted rounded-2xl">
-                  <LoadingDots />
-                </div>
-              </div>
-            )}
-          </div>
-        </ScrollArea>
-
-        {/* Input Area */}
-        <div className="border-t p-4">
-          <div className="mx-auto flex max-w-3xl items-end gap-2">
-            <Textarea
-              ref={textareaRef}
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Type your message..."
-              className="max-h-32 min-h-10 resize-none"
-              rows={1}
-              disabled={isLoading}
-            />
-            <Button
-              onClick={handleSend}
-              disabled={!input.trim() || isLoading}
-              size="icon"
-              className="h-10 w-10 shrink-0"
-            >
-              <Send className="h-4 w-4" />
-            </Button>
-          </div>
-          <p className="text-muted-foreground mx-auto mt-2 max-w-3xl text-center text-[10px]">
-            Press Enter to send, Shift+Enter for new line
-          </p>
-        </div>
+        {/* AgentChat — streaming agentic chat */}
+        <AgentChat
+          apiEndpoint="/api/agents/coach"
+          body={{ resumeId: selectedResumeId }}
+          onToolResult={handleToolResult}
+          onMessagesChange={handleMessagesChange}
+          placeholder="Tell me about a role, project, or skill..."
+          emptyMessage={getWelcomeMessage(session.session_type)}
+        />
       </div>
 
       {/* Sidebar for builder sessions */}
@@ -405,21 +174,28 @@ export function ChatInterface({ session, resumes }: ChatInterfaceProps) {
           <Separator orientation="vertical" />
           <div className="hidden w-80 flex-col lg:flex">
             <div className="border-b px-4 py-3">
-              <h3 className="text-sm font-semibold">
-                {session.session_type === "experience_builder"
-                  ? "Generated Bullets"
-                  : "Generated Descriptions"}
-              </h3>
+              <h3 className="text-sm font-semibold">Saved Items</h3>
               <p className="text-muted-foreground text-xs">
-                {generatedBullets.length} item
-                {generatedBullets.length !== 1 ? "s" : ""} generated
+                {savedItems.length} item{savedItems.length !== 1 ? "s" : ""} saved to resume
               </p>
             </div>
             <ScrollArea className="flex-1">
-              <GeneratedContentPanel
-                sessionType={session.session_type}
-                bullets={generatedBullets}
-              />
+              <div className="p-4">
+                {savedItems.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-8 text-center">
+                    <FileText className="text-muted-foreground mb-2 h-8 w-8" />
+                    <p className="text-muted-foreground text-sm">
+                      Items will appear here as the coach saves them to your resume.
+                    </p>
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {savedItems.map((item, i) => (
+                      <BulletItem key={i} text={item} />
+                    ))}
+                  </div>
+                )}
+              </div>
             </ScrollArea>
           </div>
         </>
@@ -433,14 +209,14 @@ export function ChatInterface({ session, resumes }: ChatInterfaceProps) {
 function getWelcomeMessage(sessionType: CoachSessionType): string {
   switch (sessionType) {
     case "experience_builder":
-      return "I'll interview you about your work experience to help generate strong, metrics-driven bullet points for your resume. Tell me about a role or project you'd like to document."
+      return "I'll interview you about your work experience to extract strong, metrics-driven bullet points. Tell me about a role or project you'd like to document."
     case "project_builder":
-      return "Let's document your projects together. Tell me about a project you've worked on, and I'll help you write compelling descriptions and achievement bullets."
+      return "Let's document your projects. Tell me about a project, and I'll help you write compelling descriptions with measurable impact."
     case "interview_prep":
-      return "I'll help you prepare for behavioral interviews using the STAR method. We can practice with questions tailored to your experience. Ready to start?"
+      return "I'll help you prepare for behavioral interviews using the STAR method. Ready to start?"
     case "career_narrative":
-      return "Let's build a cohesive story that connects your experiences. Tell me about your career journey, and I'll help you craft a compelling narrative."
+      return "Let's build a cohesive story that connects your experiences. Tell me about your career journey."
     default:
-      return "I'm your AI career coach. Ask me anything about your career, resume strategy, job search, or professional development."
+      return "I'm your AI career coach. Ask me anything about your career, resume strategy, or professional development."
   }
 }

--- a/src/app/admin/resume-builder/career-coach/[id]/chat-interface.tsx
+++ b/src/app/admin/resume-builder/career-coach/[id]/chat-interface.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/select"
 import { toast } from "sonner"
 import { AgentChat } from "@/components/agent-chat"
+import { ChatSettingsPopover } from "./chat-settings-popover"
 import { updateCoachSessionMessages } from "../actions"
 import type { CareerCoachSession, CoachSessionType, Resume } from "@/types/resume-builder"
 
@@ -72,9 +73,14 @@ function BulletItem({ text }: { text: string }) {
 interface ChatInterfaceProps {
   session: CareerCoachSession
   resumes: Resume[]
+  agentConfig: {
+    model_id: string | null
+    max_tokens: number | null
+    system_prompt: string | null
+  }
 }
 
-export function ChatInterface({ session, resumes }: ChatInterfaceProps) {
+export function ChatInterface({ session, resumes, agentConfig }: ChatInterfaceProps) {
   const [selectedResumeId, setSelectedResumeId] = useState<string>(resumes[0]?.id ?? "")
   const [savedItems, setSavedItems] = useState<string[]>([])
 
@@ -129,6 +135,7 @@ export function ChatInterface({ session, resumes }: ChatInterfaceProps) {
             </Badge>
           </div>
           <div className="flex items-center gap-2">
+            <ChatSettingsPopover slug="career_interviewer" initialConfig={agentConfig} />
             {selectedResume && (
               <Badge variant="outline" className="gap-1">
                 <FileText className="h-3 w-3" />
@@ -160,11 +167,18 @@ export function ChatInterface({ session, resumes }: ChatInterfaceProps) {
         {/* AgentChat — streaming agentic chat */}
         <AgentChat
           apiEndpoint="/api/agents/coach"
-          body={{ resumeId: selectedResumeId }}
+          body={{ resumeId: selectedResumeId, sessionType: session.session_type }}
+          initialMessages={[
+            {
+              id: "greeting",
+              role: "assistant" as const,
+              parts: [{ type: "text" as const, text: getWelcomeMessage(session.session_type) }],
+            },
+          ]}
           onToolResult={handleToolResult}
           onMessagesChange={handleMessagesChange}
           placeholder="Tell me about a role, project, or skill..."
-          emptyMessage={getWelcomeMessage(session.session_type)}
+          emptyStateIcon={Icon}
         />
       </div>
 

--- a/src/app/admin/resume-builder/career-coach/[id]/chat-settings-popover.tsx
+++ b/src/app/admin/resume-builder/career-coach/[id]/chat-settings-popover.tsx
@@ -7,11 +7,7 @@ import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Slider } from "@/components/ui/slider"
 import { Badge } from "@/components/ui/badge"
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import {
   Select,
   SelectContent,
@@ -49,13 +45,16 @@ export function ChatSettingsPopover({ slug, initialConfig }: ChatSettingsPopover
         })
         toast.success("Agent settings saved")
         setOpen(false)
-      } catch (err) {
+      } catch {
         toast.error("Failed to save settings")
       }
     })
   }
 
-  const modelEntries = Object.entries(AVAILABLE_MODELS) as [string, (typeof AVAILABLE_MODELS)[ModelId]][]
+  const modelEntries = Object.entries(AVAILABLE_MODELS) as [
+    string,
+    (typeof AVAILABLE_MODELS)[ModelId],
+  ][]
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -67,7 +66,7 @@ export function ChatSettingsPopover({ slug, initialConfig }: ChatSettingsPopover
       <PopoverContent className="w-96" align="end">
         <div className="space-y-4">
           <div>
-            <h4 className="font-medium text-sm mb-1">Agent Settings</h4>
+            <h4 className="mb-1 text-sm font-medium">Agent Settings</h4>
             <p className="text-muted-foreground text-xs">
               Changes apply to all future messages in this agent.
             </p>
@@ -85,7 +84,7 @@ export function ChatSettingsPopover({ slug, initialConfig }: ChatSettingsPopover
                   <SelectItem key={id} value={id}>
                     <div className="flex items-center gap-2">
                       <span>{info.label}</span>
-                      <Badge variant="outline" className="text-[10px] px-1 py-0">
+                      <Badge variant="outline" className="px-1 py-0 text-[10px]">
                         {info.tier}
                       </Badge>
                     </div>
@@ -99,7 +98,7 @@ export function ChatSettingsPopover({ slug, initialConfig }: ChatSettingsPopover
           <div className="space-y-2">
             <div className="flex items-center justify-between">
               <Label className="text-xs">Max Tokens</Label>
-              <span className="text-muted-foreground text-xs font-mono">{maxTokens}</span>
+              <span className="text-muted-foreground font-mono text-xs">{maxTokens}</span>
             </div>
             <Slider
               value={[maxTokens]}
@@ -117,7 +116,7 @@ export function ChatSettingsPopover({ slug, initialConfig }: ChatSettingsPopover
               value={systemPrompt}
               onChange={(e) => setSystemPrompt(e.target.value)}
               rows={6}
-              className="text-xs font-mono resize-y"
+              className="resize-y font-mono text-xs"
             />
           </div>
 

--- a/src/app/admin/resume-builder/career-coach/[id]/chat-settings-popover.tsx
+++ b/src/app/admin/resume-builder/career-coach/[id]/chat-settings-popover.tsx
@@ -1,0 +1,133 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { Settings2, Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Slider } from "@/components/ui/slider"
+import { Badge } from "@/components/ui/badge"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { toast } from "sonner"
+import { AVAILABLE_MODELS, DEFAULT_MODEL_ID, type ModelId } from "@/lib/ai/models"
+import { updateAgentConfig } from "../actions"
+
+interface ChatSettingsPopoverProps {
+  slug: string
+  initialConfig: {
+    model_id: string | null
+    max_tokens: number | null
+    system_prompt: string | null
+  }
+}
+
+export function ChatSettingsPopover({ slug, initialConfig }: ChatSettingsPopoverProps) {
+  const [modelId, setModelId] = useState(initialConfig.model_id ?? DEFAULT_MODEL_ID)
+  const [maxTokens, setMaxTokens] = useState(initialConfig.max_tokens ?? 4096)
+  const [systemPrompt, setSystemPrompt] = useState(initialConfig.system_prompt ?? "")
+  const [open, setOpen] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  function handleSave() {
+    startTransition(async () => {
+      try {
+        await updateAgentConfig(slug, {
+          model_id: modelId,
+          max_tokens: maxTokens,
+          system_prompt: systemPrompt,
+        })
+        toast.success("Agent settings saved")
+        setOpen(false)
+      } catch (err) {
+        toast.error("Failed to save settings")
+      }
+    })
+  }
+
+  const modelEntries = Object.entries(AVAILABLE_MODELS) as [string, (typeof AVAILABLE_MODELS)[ModelId]][]
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="icon" className="h-8 w-8">
+          <Settings2 className="h-4 w-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-96" align="end">
+        <div className="space-y-4">
+          <div>
+            <h4 className="font-medium text-sm mb-1">Agent Settings</h4>
+            <p className="text-muted-foreground text-xs">
+              Changes apply to all future messages in this agent.
+            </p>
+          </div>
+
+          {/* Model Selector */}
+          <div className="space-y-2">
+            <Label className="text-xs">Model</Label>
+            <Select value={modelId} onValueChange={setModelId}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {modelEntries.map(([id, info]) => (
+                  <SelectItem key={id} value={id}>
+                    <div className="flex items-center gap-2">
+                      <span>{info.label}</span>
+                      <Badge variant="outline" className="text-[10px] px-1 py-0">
+                        {info.tier}
+                      </Badge>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Max Tokens Slider */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label className="text-xs">Max Tokens</Label>
+              <span className="text-muted-foreground text-xs font-mono">{maxTokens}</span>
+            </div>
+            <Slider
+              value={[maxTokens]}
+              onValueChange={([v]) => setMaxTokens(v)}
+              min={512}
+              max={8192}
+              step={256}
+            />
+          </div>
+
+          {/* System Prompt */}
+          <div className="space-y-2">
+            <Label className="text-xs">System Prompt</Label>
+            <Textarea
+              value={systemPrompt}
+              onChange={(e) => setSystemPrompt(e.target.value)}
+              rows={6}
+              className="text-xs font-mono resize-y"
+            />
+          </div>
+
+          {/* Save */}
+          <Button onClick={handleSave} disabled={isPending} className="w-full" size="sm">
+            {isPending && <Loader2 className="mr-2 h-3 w-3 animate-spin" />}
+            Save Settings
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/app/admin/resume-builder/career-coach/[id]/page.tsx
+++ b/src/app/admin/resume-builder/career-coach/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation"
 import { AdminHeader } from "../../../admin-header"
 import { getCoachSession, getResumes } from "@/lib/resume-builder/queries"
+import { getAgentConfig } from "../actions"
 import { ChatInterface } from "./chat-interface"
 
 interface ChatPageProps {
@@ -9,14 +10,14 @@ interface ChatPageProps {
 
 export default async function ChatPage({ params }: ChatPageProps) {
   const { id } = await params
-  const [session, resumes] = await Promise.all([getCoachSession(id), getResumes()])
+  const [session, resumes, agentConfig] = await Promise.all([getCoachSession(id), getResumes(), getAgentConfig("career_interviewer")])
 
   if (!session) notFound()
 
   return (
     <>
       <AdminHeader title="Career Coach" />
-      <ChatInterface session={session} resumes={resumes} />
+      <ChatInterface session={session} resumes={resumes} agentConfig={agentConfig ?? { model_id: null, max_tokens: null, system_prompt: null }} />
     </>
   )
 }

--- a/src/app/admin/resume-builder/career-coach/[id]/page.tsx
+++ b/src/app/admin/resume-builder/career-coach/[id]/page.tsx
@@ -10,14 +10,22 @@ interface ChatPageProps {
 
 export default async function ChatPage({ params }: ChatPageProps) {
   const { id } = await params
-  const [session, resumes, agentConfig] = await Promise.all([getCoachSession(id), getResumes(), getAgentConfig("career_interviewer")])
+  const [session, resumes, agentConfig] = await Promise.all([
+    getCoachSession(id),
+    getResumes(),
+    getAgentConfig("career_interviewer"),
+  ])
 
   if (!session) notFound()
 
   return (
     <>
       <AdminHeader title="Career Coach" />
-      <ChatInterface session={session} resumes={resumes} agentConfig={agentConfig ?? { model_id: null, max_tokens: null, system_prompt: null }} />
+      <ChatInterface
+        session={session}
+        resumes={resumes}
+        agentConfig={agentConfig ?? { model_id: null, max_tokens: null, system_prompt: null }}
+      />
     </>
   )
 }

--- a/src/app/admin/resume-builder/career-coach/actions.ts
+++ b/src/app/admin/resume-builder/career-coach/actions.ts
@@ -73,7 +73,11 @@ export async function getAgentConfig(slug: string) {
     .single()
 
   if (error) return null
-  return data as { model_id: string | null; max_tokens: number | null; system_prompt: string | null }
+  return data as {
+    model_id: string | null
+    max_tokens: number | null
+    system_prompt: string | null
+  }
 }
 
 export async function updateAgentConfig(

--- a/src/app/admin/resume-builder/career-coach/actions.ts
+++ b/src/app/admin/resume-builder/career-coach/actions.ts
@@ -63,3 +63,32 @@ export async function updateCoachSessionContent(
   if (error) throw new Error(error.message)
   revalidatePath(`/admin/resume-builder/career-coach/${id}`)
 }
+
+export async function getAgentConfig(slug: string) {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("ai_prompts")
+    .select("model_id, max_tokens, system_prompt")
+    .eq("slug", slug)
+    .single()
+
+  if (error) return null
+  return data as { model_id: string | null; max_tokens: number | null; system_prompt: string | null }
+}
+
+export async function updateAgentConfig(
+  slug: string,
+  config: { model_id?: string; max_tokens?: number; system_prompt?: string },
+) {
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from("ai_prompts")
+    .update({
+      ...config,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("slug", slug)
+
+  if (error) throw new Error(error.message)
+  revalidatePath("/admin/resume-builder/career-coach")
+}

--- a/src/app/admin/resume-builder/tailor/page.tsx
+++ b/src/app/admin/resume-builder/tailor/page.tsx
@@ -1,0 +1,14 @@
+import { AdminHeader } from "../../admin-header"
+import { getResumes } from "@/lib/resume-builder/queries"
+import { TailorClient } from "./tailor-client"
+
+export default async function TailorPage() {
+  const resumes = await getResumes()
+
+  return (
+    <>
+      <AdminHeader title="Resume Tailor" />
+      <TailorClient resumes={resumes} />
+    </>
+  )
+}

--- a/src/app/admin/resume-builder/tailor/tailor-client.tsx
+++ b/src/app/admin/resume-builder/tailor/tailor-client.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import { FileText } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { toast } from "sonner"
+import { AgentChat } from "@/components/agent-chat"
+import type { Resume } from "@/types/resume-builder"
+
+interface TailorClientProps {
+  resumes: Resume[]
+}
+
+export function TailorClient({ resumes }: TailorClientProps) {
+  const [selectedResumeId, setSelectedResumeId] = useState<string>(resumes[0]?.id ?? "")
+
+  const selectedResume = resumes.find((r) => r.id === selectedResumeId)
+
+  const handleToolResult = useCallback((toolName: string, result: unknown) => {
+    const r = result as { success?: boolean; message?: string }
+    if (r?.success && r?.message) {
+      toast.success(r.message)
+    }
+  }, [])
+
+  if (resumes.length === 0) {
+    return (
+      <div className="flex h-[calc(100vh-56px)] items-center justify-center">
+        <div className="text-center">
+          <FileText className="text-muted-foreground mx-auto mb-3 h-10 w-10" />
+          <p className="text-muted-foreground text-sm">Create a resume first to use the Tailor.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ height: "calc(100vh - 56px)" }} className="flex flex-col">
+      {/* Resume selector bar */}
+      <div className="flex items-center gap-3 border-b px-4 py-2.5">
+        <span className="text-muted-foreground text-xs font-medium">Resume:</span>
+        <Select value={selectedResumeId} onValueChange={setSelectedResumeId}>
+          <SelectTrigger className="h-8 w-60 text-xs">
+            <SelectValue placeholder="Select resume" />
+          </SelectTrigger>
+          <SelectContent>
+            {resumes.map((resume) => (
+              <SelectItem key={resume.id} value={resume.id}>
+                {resume.title}
+                {resume.is_master && (
+                  <Badge variant="secondary" className="ml-2 text-[9px]">
+                    Master
+                  </Badge>
+                )}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {selectedResume && (
+          <Badge variant="outline" className="text-[10px]">
+            {selectedResume.target_role ?? "No target role"}
+          </Badge>
+        )}
+      </div>
+
+      {/* Agent chat */}
+      <div className="flex-1">
+        <AgentChat
+          key={selectedResumeId}
+          apiEndpoint="/api/agents/tailor"
+          body={{ resumeId: selectedResumeId }}
+          onToolResult={handleToolResult}
+          placeholder="Paste a job description or ask me to tailor your resume..."
+          emptyMessage="I'm your Resume Tailor. Paste a job description and I'll analyze it, match it against your resume, and generate tailored bullet points."
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/agents/architect/route.ts
+++ b/src/app/api/agents/architect/route.ts
@@ -1,0 +1,39 @@
+import { streamText, UIMessage, convertToModelMessages } from "ai"
+import { createClient } from "@/lib/supabase/server"
+import { getModel } from "@/lib/ai/models"
+
+export const maxDuration = 60
+
+export async function POST(req: Request) {
+  // Auth guard
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return new Response("Unauthorized", { status: 401 })
+  }
+
+  const { messages }: { messages: UIMessage[] } = await req.json()
+
+  // Fetch agent system prompt from DB
+  const { data: agentPrompt } = await supabase
+    .from("ai_prompts")
+    .select("system_prompt, model_id")
+    .eq("slug", "enterprise_architect")
+    .single()
+
+  const systemPrompt =
+    agentPrompt?.system_prompt ??
+    "You are a Veteran Systems Engineering Agent. Design architectures and output Mermaid.js diagrams."
+
+  const modelId = agentPrompt?.model_id ?? undefined
+
+  const result = streamText({
+    model: getModel(modelId),
+    system: systemPrompt,
+    messages: await convertToModelMessages(messages),
+  })
+
+  return result.toUIMessageStreamResponse()
+}

--- a/src/app/api/agents/coach/route.ts
+++ b/src/app/api/agents/coach/route.ts
@@ -1,0 +1,74 @@
+import { streamText, UIMessage, convertToModelMessages, stepCountIs } from "ai"
+import { createClient } from "@/lib/supabase/server"
+import { getModel } from "@/lib/ai/models"
+import { createInterviewerTools } from "@/lib/ai/tools/career-interviewer"
+
+export const maxDuration = 60
+
+export async function POST(req: Request) {
+  // Auth guard
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return new Response("Unauthorized", { status: 401 })
+  }
+
+  const {
+    messages,
+    resumeId,
+  }: {
+    messages: UIMessage[]
+    resumeId: string
+  } = await req.json()
+
+  if (!resumeId) {
+    return new Response("resumeId is required", { status: 400 })
+  }
+
+  // Fetch agent system prompt from DB
+  const { data: agentPrompt } = await supabase
+    .from("ai_prompts")
+    .select("system_prompt, model_id")
+    .eq("slug", "career_interviewer")
+    .single()
+
+  const systemPrompt =
+    agentPrompt?.system_prompt ??
+    "You are an elite Career Coach. Interview the user about their career experience and save structured data using the provided tools."
+
+  const modelId = agentPrompt?.model_id ?? undefined
+
+  // Build existing career data context for deduplication
+  const { data: existingExperiences } = await supabase
+    .from("resume_work_experiences")
+    .select("job_title, company")
+    .eq("resume_id", resumeId)
+
+  const { data: existingProjects } = await supabase
+    .from("resume_projects")
+    .select("name")
+    .eq("resume_id", resumeId)
+
+  const existingContext =
+    existingExperiences?.length || existingProjects?.length
+      ? `\n\n<existing_career_data>
+Already documented experiences: ${(existingExperiences ?? []).map((e) => `${e.job_title} at ${e.company}`).join(", ") || "None"}
+Already documented projects: ${(existingProjects ?? []).map((p) => p.name).join(", ") || "None"}
+Do NOT save duplicate entries for these.
+</existing_career_data>`
+      : ""
+
+  const tools = createInterviewerTools(resumeId)
+
+  const result = streamText({
+    model: getModel(modelId),
+    system: systemPrompt + existingContext,
+    messages: await convertToModelMessages(messages),
+    tools,
+    stopWhen: stepCountIs(5),
+  })
+
+  return result.toUIMessageStreamResponse()
+}

--- a/src/app/api/agents/coach/route.ts
+++ b/src/app/api/agents/coach/route.ts
@@ -18,9 +18,11 @@ export async function POST(req: Request) {
   const {
     messages,
     resumeId,
+    sessionType,
   }: {
     messages: UIMessage[]
     resumeId: string
+    sessionType?: string
   } = await req.json()
 
   if (!resumeId) {
@@ -30,7 +32,7 @@ export async function POST(req: Request) {
   // Fetch agent system prompt from DB
   const { data: agentPrompt } = await supabase
     .from("ai_prompts")
-    .select("system_prompt, model_id")
+    .select("system_prompt, model_id, max_tokens")
     .eq("slug", "career_interviewer")
     .single()
 
@@ -39,6 +41,7 @@ export async function POST(req: Request) {
     "You are an elite Career Coach. Interview the user about their career experience and save structured data using the provided tools."
 
   const modelId = agentPrompt?.model_id ?? undefined
+  const maxTokens = agentPrompt?.max_tokens ?? 4096
 
   // Build existing career data context for deduplication
   const { data: existingExperiences } = await supabase
@@ -60,15 +63,68 @@ Do NOT save duplicate entries for these.
 </existing_career_data>`
       : ""
 
+  const sessionAddendum = getSessionTypeAddendum(sessionType)
+
   const tools = createInterviewerTools(resumeId)
 
   const result = streamText({
     model: getModel(modelId),
-    system: systemPrompt + existingContext,
+    system: systemPrompt + existingContext + sessionAddendum,
     messages: await convertToModelMessages(messages),
     tools,
+    maxOutputTokens: maxTokens,
     stopWhen: stepCountIs(5),
   })
 
   return result.toUIMessageStreamResponse()
+}
+
+function getSessionTypeAddendum(sessionType?: string): string {
+  switch (sessionType) {
+    case "project_builder":
+      return `\n\n<session_instructions>
+You are in PROJECT BUILDER mode. Your goal is to document the user's projects with compelling descriptions and measurable impact.
+- Ask about each project's company context (was it built at work, freelance, personal?)
+- Ask about the tech stack, architecture decisions, and challenges overcome
+- Probe for measurable impact: users served, performance gains, time saved, revenue impact
+- Always include the company field when saving projects using the save_project tool
+- Help craft 2-4 achievement bullets per project using the XYZ formula
+</session_instructions>`
+
+    case "experience_builder":
+      return `\n\n<session_instructions>
+You are in EXPERIENCE BUILDER mode. Your goal is to interview the user about their work history and extract strong, metrics-driven bullet points.
+- Interview about each role: responsibilities, team size, scope, key achievements
+- Extract XYZ-formula bullets: "Accomplished [X] as measured by [Y] by doing [Z]"
+- Ask probing follow-ups to uncover metrics: "How many users?", "What was the performance improvement?", "How much time did this save?"
+- Cover 2-5 achievement bullets per role before moving to the next
+- Prioritize quantifiable results over vague descriptions
+</session_instructions>`
+
+    case "interview_prep":
+      return `\n\n<session_instructions>
+You are in INTERVIEW PREP mode. Your goal is to help the user practice behavioral interview questions using the STAR method.
+- Present one behavioral question at a time (e.g., "Tell me about a time you dealt with a difficult stakeholder")
+- After the user answers, provide structured feedback on their STAR response:
+  - Situation: Was the context clear?
+  - Task: Was the responsibility well-defined?
+  - Action: Were specific actions described?
+  - Result: Were outcomes quantified?
+- Suggest improvements and offer a follow-up question
+- Cover common categories: leadership, conflict, failure, teamwork, technical challenges
+</session_instructions>`
+
+    case "career_narrative":
+      return `\n\n<session_instructions>
+You are in CAREER NARRATIVE mode. Your goal is to help the user build a cohesive story that connects their experiences.
+- Ask about career transitions: why they moved between roles, industries, or technologies
+- Help identify themes and throughlines across their career (e.g., "scaling systems", "developer experience")
+- Connect the narrative to their target role — how does their journey lead naturally to where they want to go?
+- Help craft a professional summary that tells this story in 2-3 sentences
+- Focus on the "why" behind career moves, not just the "what"
+</session_instructions>`
+
+    default:
+      return ""
+  }
 }

--- a/src/app/api/agents/tailor/route.ts
+++ b/src/app/api/agents/tailor/route.ts
@@ -1,0 +1,59 @@
+import { streamText, UIMessage, convertToModelMessages, stepCountIs } from "ai"
+import { createClient } from "@/lib/supabase/server"
+import { getModel } from "@/lib/ai/models"
+import { createTailorTools } from "@/lib/ai/tools/resume-tailor"
+import { buildCareerContext } from "@/lib/ai/context-builder"
+
+export const maxDuration = 60
+
+export async function POST(req: Request) {
+  // Auth guard
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return new Response("Unauthorized", { status: 401 })
+  }
+
+  const {
+    messages,
+    resumeId,
+  }: {
+    messages: UIMessage[]
+    resumeId: string
+  } = await req.json()
+
+  if (!resumeId) {
+    return new Response("resumeId is required", { status: 400 })
+  }
+
+  // Fetch agent system prompt from DB
+  const { data: agentPrompt } = await supabase
+    .from("ai_prompts")
+    .select("system_prompt, model_id")
+    .eq("slug", "resume_tailor")
+    .single()
+
+  const systemPrompt =
+    agentPrompt?.system_prompt ??
+    "You are an Executive Resume Writer. Tailor existing experience to specific job descriptions with ATS optimization."
+
+  const modelId = agentPrompt?.model_id ?? undefined
+
+  // Build career context from resume data
+  const careerContext = await buildCareerContext(resumeId)
+  const contextBlock = careerContext ? `\n\n<career_data>\n${careerContext}\n</career_data>` : ""
+
+  const tools = createTailorTools(resumeId)
+
+  const result = streamText({
+    model: getModel(modelId),
+    system: systemPrompt + contextBlock,
+    messages: await convertToModelMessages(messages),
+    tools,
+    stopWhen: stepCountIs(5),
+  })
+
+  return result.toUIMessageStreamResponse()
+}

--- a/src/app/api/agents/test/route.ts
+++ b/src/app/api/agents/test/route.ts
@@ -1,0 +1,26 @@
+import { streamText, UIMessage, convertToModelMessages } from "ai"
+import { createClient } from "@/lib/supabase/server"
+import { getModel } from "@/lib/ai/models"
+
+export const maxDuration = 30
+
+export async function POST(req: Request) {
+  // Auth guard
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return new Response("Unauthorized", { status: 401 })
+  }
+
+  const { messages }: { messages: UIMessage[] } = await req.json()
+
+  const result = streamText({
+    model: getModel("us.anthropic.claude-3-5-haiku-20241022-v1:0"),
+    system: "You are a helpful assistant. Keep responses brief.",
+    messages: await convertToModelMessages(messages),
+  })
+
+  return result.toUIMessageStreamResponse()
+}

--- a/src/components/CustomCursor.tsx
+++ b/src/components/CustomCursor.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState, useSyncExternalStore } from "react"
-import gsap from "gsap"
+import { useEffect, useRef, useSyncExternalStore } from "react"
 
 const TOUCH_QUERY = "(pointer: coarse)"
 
@@ -18,57 +17,83 @@ function getIsTouch() {
 export function CustomCursor() {
   const cursorRef = useRef<HTMLDivElement>(null)
   const cursorDotRef = useRef<HTMLDivElement>(null)
-  const [isHovering, setIsHovering] = useState(false)
-  const [isVisible, setIsVisible] = useState(false)
+  const ringRef = useRef<HTMLDivElement>(null)
+  const dotRef = useRef<HTMLDivElement>(null)
+  const isVisibleRef = useRef(false)
+  const cleanupRef = useRef<(() => void) | null>(null)
   const isTouch = useSyncExternalStore(subscribeTouchChange, getIsTouch, () => false)
 
   useEffect(() => {
     if (isTouch) return
 
-    const moveCursor = (e: MouseEvent) => {
-      if (!isVisible) setIsVisible(true)
+    const init = async () => {
+      const { default: gsap } = await import("gsap")
 
-      gsap.to(cursorRef.current, {
-        x: e.clientX,
-        y: e.clientY,
-        duration: 0.5,
-        ease: "power3.out",
-      })
+      const moveCursor = (e: MouseEvent) => {
+        if (!isVisibleRef.current) {
+          isVisibleRef.current = true
+          if (cursorRef.current) cursorRef.current.style.opacity = "1"
+          if (cursorDotRef.current) cursorDotRef.current.style.opacity = "1"
+        }
 
-      gsap.to(cursorDotRef.current, {
-        x: e.clientX,
-        y: e.clientY,
-        duration: 0.1,
-      })
+        gsap.to(cursorRef.current, {
+          x: e.clientX,
+          y: e.clientY,
+          duration: 0.5,
+          ease: "power3.out",
+        })
+
+        gsap.to(cursorDotRef.current, {
+          x: e.clientX,
+          y: e.clientY,
+          duration: 0.1,
+        })
+      }
+
+      const handleMouseEnter = () => {
+        gsap.to(ringRef.current, { width: 56, height: 56, opacity: 0.6, duration: 0.3 })
+        gsap.to(dotRef.current, { width: 8, height: 8, duration: 0.3 })
+      }
+
+      const handleMouseLeave = () => {
+        gsap.to(ringRef.current, { width: 36, height: 36, opacity: 0.4, duration: 0.3 })
+        gsap.to(dotRef.current, { width: 5, height: 5, duration: 0.3 })
+      }
+
+      window.addEventListener("mousemove", moveCursor, { passive: true })
+
+      const handleOverInteractive = (e: Event) => {
+        const target = e.target as HTMLElement
+        if (
+          target.closest("a, button, [role='button'], input, textarea, select, [data-cursor-hover]")
+        ) {
+          handleMouseEnter()
+        }
+      }
+
+      const handleOutInteractive = (e: Event) => {
+        const target = e.target as HTMLElement
+        if (
+          target.closest("a, button, [role='button'], input, textarea, select, [data-cursor-hover]")
+        ) {
+          handleMouseLeave()
+        }
+      }
+
+      document.addEventListener("mouseover", handleOverInteractive, { passive: true })
+      document.addEventListener("mouseout", handleOutInteractive, { passive: true })
+
+      // Store cleanup refs
+      cleanupRef.current = () => {
+        window.removeEventListener("mousemove", moveCursor)
+        document.removeEventListener("mouseover", handleOverInteractive)
+        document.removeEventListener("mouseout", handleOutInteractive)
+      }
     }
 
-    const handleMouseEnter = () => {
-      setIsHovering(true)
-    }
-
-    const handleMouseLeave = () => {
-      setIsHovering(false)
-    }
-
-    window.addEventListener("mousemove", moveCursor, { passive: true })
-
-    const interactiveElements = document.querySelectorAll(
-      "a, button, [role='button'], input, textarea, select, [data-cursor-hover]",
-    )
-
-    interactiveElements.forEach((el) => {
-      el.addEventListener("mouseenter", handleMouseEnter)
-      el.addEventListener("mouseleave", handleMouseLeave)
-    })
-
-    return () => {
-      window.removeEventListener("mousemove", moveCursor)
-      interactiveElements.forEach((el) => {
-        el.removeEventListener("mouseenter", handleMouseEnter)
-        el.removeEventListener("mouseleave", handleMouseLeave)
-      })
-    }
-  }, [isVisible, isTouch])
+    init()
+    return () => cleanupRef.current?.()
+  }, [isTouch])
 
   if (isTouch) return null
 
@@ -78,15 +103,16 @@ export function CustomCursor() {
       <div
         ref={cursorRef}
         className="pointer-events-none fixed top-0 left-0 z-[10000] -translate-x-1/2 -translate-y-1/2 mix-blend-difference"
-        style={{ opacity: isVisible ? 1 : 0 }}
+        style={{ opacity: 0 }}
       >
         <div
-          className="rounded-full border border-white transition-all duration-300"
+          ref={ringRef}
+          className="rounded-full border border-white"
           style={{
-            width: isHovering ? 56 : 36,
-            height: isHovering ? 56 : 36,
-            opacity: isHovering ? 0.6 : 0.4,
-            transform: `translate(-50%, -50%)`,
+            width: 36,
+            height: 36,
+            opacity: 0.4,
+            transform: "translate(-50%, -50%)",
           }}
         />
       </div>
@@ -94,14 +120,15 @@ export function CustomCursor() {
       <div
         ref={cursorDotRef}
         className="pointer-events-none fixed top-0 left-0 z-[10001] -translate-x-1/2 -translate-y-1/2 mix-blend-difference"
-        style={{ opacity: isVisible ? 1 : 0 }}
+        style={{ opacity: 0 }}
       >
         <div
-          className="rounded-full bg-white transition-all duration-300"
+          ref={dotRef}
+          className="rounded-full bg-white"
           style={{
-            width: isHovering ? 8 : 5,
-            height: isHovering ? 8 : 5,
-            transform: `translate(-50%, -50%)`,
+            width: 5,
+            height: 5,
+            transform: "translate(-50%, -50%)",
           }}
         />
       </div>

--- a/src/components/agent-chat/agent-chat.tsx
+++ b/src/components/agent-chat/agent-chat.tsx
@@ -3,8 +3,9 @@
 import { useRef, useEffect, useState, type ReactNode } from "react"
 import { useChat, type UIMessage } from "@ai-sdk/react"
 import { DefaultChatTransport } from "ai"
-import { Send, Square, MessageSquare } from "lucide-react"
+import { ArrowUp, Square, MessageSquare, type LucideIcon } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { cn } from "@/lib/utils"
 import { MessageBubble } from "./message-bubble"
@@ -29,6 +30,8 @@ export interface AgentChatProps {
   placeholder?: string
   /** Empty state message */
   emptyMessage?: string
+  /** Custom icon for the empty state (defaults to MessageSquare) */
+  emptyStateIcon?: LucideIcon
   className?: string
 }
 
@@ -133,6 +136,7 @@ export function AgentChat({
   renderCustomBlock,
   placeholder = "Type your message...",
   emptyMessage = "Start a conversation to begin.",
+  emptyStateIcon: EmptyIcon = MessageSquare,
   className,
 }: AgentChatProps) {
   const [input, setInput] = useState("")
@@ -184,7 +188,7 @@ export function AgentChat({
   useEffect(() => {
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto"
-      textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 128)}px`
+      textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 200)}px`
     }
   }, [input])
 
@@ -211,7 +215,9 @@ export function AgentChat({
         <div className="mx-auto max-w-3xl space-y-4 py-4">
           {messages.length === 0 && (
             <div className="text-muted-foreground flex flex-col items-center justify-center py-20 text-center">
-              <MessageSquare className="mb-3 size-10 opacity-40" />
+              <div className="bg-muted/50 mb-4 rounded-full p-4">
+                <EmptyIcon className="size-10 opacity-40" />
+              </div>
               <p className="text-sm">{emptyMessage}</p>
             </div>
           )}
@@ -277,38 +283,59 @@ export function AgentChat({
       </ScrollArea>
 
       {/* Input */}
-      <div className="bg-background border-t px-4 py-3">
-        <form onSubmit={handleSubmit} className="mx-auto flex max-w-3xl items-end gap-2">
-          <textarea
-            ref={textareaRef}
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            disabled={isLoading}
-            rows={1}
-            className="bg-muted/50 placeholder:text-muted-foreground focus:border-primary flex-1 resize-none rounded-lg border px-4 py-3 text-sm transition-colors outline-none disabled:opacity-50"
-          />
+      <div className="bg-background px-4 pb-4 pt-2">
+        <form onSubmit={handleSubmit} className="mx-auto max-w-3xl">
+          <div
+            className={cn(
+              "bg-muted/30 relative rounded-2xl border transition-all",
+              "focus-within:ring-2 focus-within:ring-primary/20 focus-within:border-primary/40",
+            )}
+          >
+            <textarea
+              ref={textareaRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder}
+              disabled={isLoading}
+              rows={1}
+              className="w-full resize-none bg-transparent px-4 pt-3 pb-12 text-sm outline-none placeholder:text-muted-foreground disabled:opacity-50"
+            />
 
-          {isLoading ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              className="size-11 shrink-0"
-              onClick={() => stop()}
-            >
-              <Square className="size-4" />
-            </Button>
-          ) : (
-            <Button type="submit" size="icon" className="size-11 shrink-0" disabled={!input.trim()}>
-              <Send className="size-4" />
-            </Button>
-          )}
+            <div className="absolute right-3 bottom-3">
+              {isLoading ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      className="size-8 rounded-lg"
+                      onClick={() => stop()}
+                    >
+                      <Square className="size-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Stop generating</TooltipContent>
+                </Tooltip>
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="submit"
+                      size="icon"
+                      className="size-8 rounded-lg"
+                      disabled={!input.trim()}
+                    >
+                      <ArrowUp className="size-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Send message (Enter)</TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+          </div>
         </form>
-        <p className="text-muted-foreground mx-auto mt-1.5 max-w-3xl text-xs">
-          Press Enter to send, Shift+Enter for new line
-        </p>
       </div>
     </div>
   )

--- a/src/components/agent-chat/agent-chat.tsx
+++ b/src/components/agent-chat/agent-chat.tsx
@@ -5,7 +5,7 @@ import { useChat, type UIMessage } from "@ai-sdk/react"
 import { DefaultChatTransport } from "ai"
 import { ArrowUp, Square, MessageSquare, type LucideIcon } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { cn } from "@/lib/utils"
 import { MessageBubble } from "./message-bubble"
@@ -209,134 +209,140 @@ export function AgentChat({
   }
 
   return (
-    <div className={cn("flex h-full flex-col", className)}>
-      {/* Messages */}
-      <ScrollArea ref={scrollRef} className="flex-1 px-4">
-        <div className="mx-auto max-w-3xl space-y-4 py-4">
-          {messages.length === 0 && (
-            <div className="text-muted-foreground flex flex-col items-center justify-center py-20 text-center">
-              <div className="bg-muted/50 mb-4 rounded-full p-4">
-                <EmptyIcon className="size-10 opacity-40" />
+    <TooltipProvider>
+      <div className={cn("flex h-full flex-col", className)}>
+        {/* Messages */}
+        <ScrollArea ref={scrollRef} className="flex-1 px-4">
+          <div className="mx-auto max-w-3xl space-y-4 py-4">
+            {messages.length === 0 && (
+              <div className="text-muted-foreground flex flex-col items-center justify-center py-20 text-center">
+                <div className="bg-muted/50 mb-4 rounded-full p-4">
+                  <EmptyIcon className="size-10 opacity-40" />
+                </div>
+                <p className="text-sm">{emptyMessage}</p>
               </div>
-              <p className="text-sm">{emptyMessage}</p>
-            </div>
-          )}
+            )}
 
-          {messages.map((message) => (
-            <div key={message.id} className="space-y-2">
-              {message.parts.map((part, index) => {
-                // Text parts — extract mermaid/json blocks
-                if (part.type === "text" && part.text) {
-                  const blocks = extractBlocks(part.text)
-                  return blocks.map((block, bi) => {
-                    if (block.type === "mermaid") {
-                      return <MermaidBlock key={`${index}-${bi}`} code={block.content} />
-                    }
-                    if (block.type === "json") {
-                      try {
-                        const parsed = JSON.parse(block.content)
-                        return <JsonPreview key={`${index}-${bi}`} data={parsed} />
-                      } catch {
-                        // Fall through to text rendering
+            {messages.map((message) => (
+              <div key={message.id} className="space-y-2">
+                {message.parts.map((part, index) => {
+                  // Text parts — extract mermaid/json blocks
+                  if (part.type === "text" && part.text) {
+                    const blocks = extractBlocks(part.text)
+                    return blocks.map((block, bi) => {
+                      if (block.type === "mermaid") {
+                        return <MermaidBlock key={`${index}-${bi}`} code={block.content} />
                       }
-                    }
-                    if (renderCustomBlock) {
-                      const custom = renderCustomBlock({ type: block.type, data: block.content })
-                      if (custom) return <div key={`${index}-${bi}`}>{custom}</div>
-                    }
+                      if (block.type === "json") {
+                        try {
+                          const parsed = JSON.parse(block.content)
+                          return <JsonPreview key={`${index}-${bi}`} data={parsed} />
+                        } catch {
+                          // Fall through to text rendering
+                        }
+                      }
+                      if (renderCustomBlock) {
+                        const custom = renderCustomBlock({ type: block.type, data: block.content })
+                        if (custom) return <div key={`${index}-${bi}`}>{custom}</div>
+                      }
+                      return (
+                        <MessageBubble
+                          key={`${index}-${bi}`}
+                          role={message.role as "user" | "assistant"}
+                          content={block.content.trim()}
+                          timestamp={new Date().toISOString()}
+                        />
+                      )
+                    })
+                  }
+
+                  // Dynamic tool parts (v6 pattern for server-defined tools)
+                  if (isToolPart(part)) {
                     return (
-                      <MessageBubble
-                        key={`${index}-${bi}`}
-                        role={message.role as "user" | "assistant"}
-                        content={block.content.trim()}
-                        timestamp={new Date().toISOString()}
+                      <ToolCallCard
+                        key={`${index}-tool`}
+                        toolName={part.toolName}
+                        state={mapToolState(part.state)}
+                        output={part.state === "output-available" ? part.output : undefined}
                       />
                     )
-                  })
-                }
+                  }
 
-                // Dynamic tool parts (v6 pattern for server-defined tools)
-                if (isToolPart(part)) {
-                  return (
-                    <ToolCallCard
-                      key={`${index}-tool`}
-                      toolName={part.toolName}
-                      state={mapToolState(part.state)}
-                      output={part.state === "output-available" ? part.output : undefined}
-                    />
-                  )
-                }
+                  return null
+                })}
+              </div>
+            ))}
 
-                return null
-              })}
-            </div>
-          ))}
+            {status === "submitted" && <LoadingDots />}
 
-          {status === "submitted" && <LoadingDots />}
-
-          {error && (
-            <div className="border-destructive/30 bg-destructive/5 text-destructive rounded-lg border px-4 py-3 text-sm">
-              {error.message || "Something went wrong. Please try again."}
-            </div>
-          )}
-        </div>
-      </ScrollArea>
-
-      {/* Input */}
-      <div className="bg-background px-4 pb-4 pt-2">
-        <form onSubmit={handleSubmit} className="mx-auto max-w-3xl">
-          <div
-            className={cn(
-              "bg-muted/30 relative rounded-2xl border transition-all",
-              "focus-within:ring-2 focus-within:ring-primary/20 focus-within:border-primary/40",
+            {error && (
+              <div className="border-destructive/30 bg-destructive/5 text-destructive rounded-lg border px-4 py-3 text-sm">
+                {error.message || "Something went wrong. Please try again."}
+              </div>
             )}
-          >
-            <textarea
-              ref={textareaRef}
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder={placeholder}
-              disabled={isLoading}
-              rows={1}
-              className="w-full resize-none bg-transparent px-4 pt-3 pb-12 text-sm outline-none placeholder:text-muted-foreground disabled:opacity-50"
-            />
-
-            <div className="absolute right-3 bottom-3">
-              {isLoading ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      className="size-8 rounded-lg"
-                      onClick={() => stop()}
-                    >
-                      <Square className="size-3.5" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>Stop generating</TooltipContent>
-                </Tooltip>
-              ) : (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      type="submit"
-                      size="icon"
-                      className="size-8 rounded-lg"
-                      disabled={!input.trim()}
-                    >
-                      <ArrowUp className="size-4" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>Send message (Enter)</TooltipContent>
-                </Tooltip>
-              )}
-            </div>
           </div>
-        </form>
+        </ScrollArea>
+
+        {/* Input */}
+        <div className="bg-background border-t px-4 py-3">
+          <form onSubmit={handleSubmit} className="mx-auto max-w-3xl">
+            <div
+              className={cn(
+                "bg-muted/50 flex overflow-hidden rounded-2xl border transition-colors",
+                "focus-within:border-primary",
+              )}
+            >
+              {/* Text region — flex-1, owns its own padding */}
+              <div className="min-w-0 flex-1 py-1 pl-5">
+                <textarea
+                  ref={textareaRef}
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder={placeholder}
+                  disabled={isLoading}
+                  rows={1}
+                  className="placeholder:text-muted-foreground block w-full resize-none bg-transparent py-2 pl-2 text-sm leading-normal outline-none disabled:opacity-50"
+                />
+              </div>
+
+              {/* Button region — fixed width, self-aligned to end */}
+              <div className="flex items-end p-2">
+                {isLoading ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        className="size-8 rounded-lg"
+                        onClick={() => stop()}
+                      >
+                        <Square className="size-3.5" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Stop generating</TooltipContent>
+                  </Tooltip>
+                ) : (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="submit"
+                        size="icon"
+                        className="size-8 rounded-lg"
+                        disabled={!input.trim()}
+                      >
+                        <ArrowUp className="size-3.5" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Send message</TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
+            </div>
+          </form>
+        </div>
       </div>
-    </div>
+    </TooltipProvider>
   )
 }

--- a/src/components/agent-chat/agent-chat.tsx
+++ b/src/components/agent-chat/agent-chat.tsx
@@ -1,0 +1,315 @@
+"use client"
+
+import { useRef, useEffect, useState, type ReactNode } from "react"
+import { useChat, type UIMessage } from "@ai-sdk/react"
+import { DefaultChatTransport } from "ai"
+import { Send, Square, MessageSquare } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { cn } from "@/lib/utils"
+import { MessageBubble } from "./message-bubble"
+import { ToolCallCard } from "./tool-call-card"
+import { MermaidBlock } from "./mermaid-block"
+import { JsonPreview } from "./json-preview"
+
+export interface AgentChatProps {
+  /** API route endpoint (e.g., "/api/agents/coach") */
+  apiEndpoint: string
+  /** Additional body params sent with every request */
+  body?: Record<string, unknown>
+  /** Initial messages to restore a previous session (v6: passed as `messages`) */
+  initialMessages?: UIMessage[]
+  /** Callback when a tool call completes */
+  onToolResult?: (toolName: string, result: unknown) => void
+  /** Callback when messages change (for persistence) */
+  onMessagesChange?: (messages: Array<{ role: string; content: string }>) => void
+  /** Custom renderer for additional block types */
+  renderCustomBlock?: (block: { type: string; data: unknown }) => ReactNode
+  /** Placeholder text for the input */
+  placeholder?: string
+  /** Empty state message */
+  emptyMessage?: string
+  className?: string
+}
+
+/** Detect and extract mermaid/json code blocks from text */
+function extractBlocks(
+  text: string,
+): Array<{ type: "text" | "mermaid" | "json"; content: string }> {
+  const blocks: Array<{ type: "text" | "mermaid" | "json"; content: string }> = []
+  const mermaidRegex = /```mermaid\n([\s\S]*?)```/g
+  const jsonRegex = /```json\n([\s\S]*?)```/g
+
+  let lastIndex = 0
+  const allMatches: Array<{
+    index: number
+    end: number
+    type: "mermaid" | "json"
+    content: string
+  }> = []
+
+  let match: RegExpExecArray | null
+  while ((match = mermaidRegex.exec(text)) !== null) {
+    allMatches.push({
+      index: match.index,
+      end: match.index + match[0].length,
+      type: "mermaid",
+      content: match[1],
+    })
+  }
+  while ((match = jsonRegex.exec(text)) !== null) {
+    allMatches.push({
+      index: match.index,
+      end: match.index + match[0].length,
+      type: "json",
+      content: match[1],
+    })
+  }
+
+  allMatches.sort((a, b) => a.index - b.index)
+
+  for (const m of allMatches) {
+    if (m.index > lastIndex) {
+      blocks.push({ type: "text", content: text.slice(lastIndex, m.index) })
+    }
+    blocks.push({ type: m.type, content: m.content })
+    lastIndex = m.end
+  }
+
+  if (lastIndex < text.length) {
+    blocks.push({ type: "text", content: text.slice(lastIndex) })
+  }
+
+  return blocks.length > 0 ? blocks : [{ type: "text", content: text }]
+}
+
+function LoadingDots() {
+  return (
+    <div className="flex items-center gap-1 px-4 py-3">
+      {[0, 150, 300].map((delay) => (
+        <div
+          key={delay}
+          className="bg-muted-foreground/50 size-2 animate-bounce rounded-full"
+          style={{ animationDelay: `${delay}ms` }}
+        />
+      ))}
+    </div>
+  )
+}
+
+/** Check if a message part is a tool invocation (dynamic-tool in v6) */
+function isToolPart(part: UIMessage["parts"][number]): part is UIMessage["parts"][number] & {
+  type: "dynamic-tool"
+  toolName: string
+  state: string
+  input?: unknown
+  output?: unknown
+  errorText?: string
+} {
+  return part.type === "dynamic-tool"
+}
+
+/** Map v6 tool states to our ToolCallCard states */
+function mapToolState(state: string): "partial-call" | "call" | "result" {
+  switch (state) {
+    case "input-streaming":
+      return "partial-call"
+    case "input-available":
+      return "call"
+    case "output-available":
+    case "output-error":
+      return "result"
+    default:
+      return "call"
+  }
+}
+
+export function AgentChat({
+  apiEndpoint,
+  body,
+  initialMessages,
+  onToolResult,
+  onMessagesChange,
+  renderCustomBlock,
+  placeholder = "Type your message...",
+  emptyMessage = "Start a conversation to begin.",
+  className,
+}: AgentChatProps) {
+  const [input, setInput] = useState("")
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const { messages, sendMessage, status, stop, error } = useChat({
+    transport: new DefaultChatTransport({
+      api: apiEndpoint,
+      body,
+    }),
+    // v6: `initialMessages` was renamed to `messages`
+    messages: initialMessages,
+    onFinish: ({ message }) => {
+      if (!onToolResult) return
+      for (const part of message.parts) {
+        if (isToolPart(part) && part.state === "output-available" && part.output !== undefined) {
+          onToolResult(part.toolName, part.output)
+        }
+      }
+    },
+  })
+
+  // Notify parent when messages change (for persistence)
+  useEffect(() => {
+    if (onMessagesChange && messages.length > 0) {
+      const simplified = messages.map((m) => ({
+        role: m.role,
+        content: m.parts
+          .filter((p): p is { type: "text"; text: string } => p.type === "text")
+          .map((p) => p.text)
+          .join(""),
+      }))
+      onMessagesChange(simplified)
+    }
+  }, [messages, onMessagesChange])
+
+  // Auto-scroll to bottom on new messages
+  useEffect(() => {
+    if (scrollRef.current) {
+      const viewport = scrollRef.current.querySelector("[data-radix-scroll-area-viewport]")
+      if (viewport) {
+        viewport.scrollTop = viewport.scrollHeight
+      }
+    }
+  }, [messages, status])
+
+  // Auto-resize textarea
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto"
+      textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 128)}px`
+    }
+  }, [input])
+
+  const isLoading = status === "submitted" || status === "streaming"
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!input.trim() || isLoading) return
+    sendMessage({ text: input.trim() })
+    setInput("")
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      handleSubmit(e)
+    }
+  }
+
+  return (
+    <div className={cn("flex h-full flex-col", className)}>
+      {/* Messages */}
+      <ScrollArea ref={scrollRef} className="flex-1 px-4">
+        <div className="mx-auto max-w-3xl space-y-4 py-4">
+          {messages.length === 0 && (
+            <div className="text-muted-foreground flex flex-col items-center justify-center py-20 text-center">
+              <MessageSquare className="mb-3 size-10 opacity-40" />
+              <p className="text-sm">{emptyMessage}</p>
+            </div>
+          )}
+
+          {messages.map((message) => (
+            <div key={message.id} className="space-y-2">
+              {message.parts.map((part, index) => {
+                // Text parts — extract mermaid/json blocks
+                if (part.type === "text" && part.text) {
+                  const blocks = extractBlocks(part.text)
+                  return blocks.map((block, bi) => {
+                    if (block.type === "mermaid") {
+                      return <MermaidBlock key={`${index}-${bi}`} code={block.content} />
+                    }
+                    if (block.type === "json") {
+                      try {
+                        const parsed = JSON.parse(block.content)
+                        return <JsonPreview key={`${index}-${bi}`} data={parsed} />
+                      } catch {
+                        // Fall through to text rendering
+                      }
+                    }
+                    if (renderCustomBlock) {
+                      const custom = renderCustomBlock({ type: block.type, data: block.content })
+                      if (custom) return <div key={`${index}-${bi}`}>{custom}</div>
+                    }
+                    return (
+                      <MessageBubble
+                        key={`${index}-${bi}`}
+                        role={message.role as "user" | "assistant"}
+                        content={block.content.trim()}
+                        timestamp={new Date().toISOString()}
+                      />
+                    )
+                  })
+                }
+
+                // Dynamic tool parts (v6 pattern for server-defined tools)
+                if (isToolPart(part)) {
+                  return (
+                    <ToolCallCard
+                      key={`${index}-tool`}
+                      toolName={part.toolName}
+                      state={mapToolState(part.state)}
+                      output={part.state === "output-available" ? part.output : undefined}
+                    />
+                  )
+                }
+
+                return null
+              })}
+            </div>
+          ))}
+
+          {status === "submitted" && <LoadingDots />}
+
+          {error && (
+            <div className="border-destructive/30 bg-destructive/5 text-destructive rounded-lg border px-4 py-3 text-sm">
+              {error.message || "Something went wrong. Please try again."}
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+
+      {/* Input */}
+      <div className="bg-background border-t px-4 py-3">
+        <form onSubmit={handleSubmit} className="mx-auto flex max-w-3xl items-end gap-2">
+          <textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            disabled={isLoading}
+            rows={1}
+            className="bg-muted/50 placeholder:text-muted-foreground focus:border-primary flex-1 resize-none rounded-lg border px-4 py-3 text-sm transition-colors outline-none disabled:opacity-50"
+          />
+
+          {isLoading ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="size-11 shrink-0"
+              onClick={() => stop()}
+            >
+              <Square className="size-4" />
+            </Button>
+          ) : (
+            <Button type="submit" size="icon" className="size-11 shrink-0" disabled={!input.trim()}>
+              <Send className="size-4" />
+            </Button>
+          )}
+        </form>
+        <p className="text-muted-foreground mx-auto mt-1.5 max-w-3xl text-xs">
+          Press Enter to send, Shift+Enter for new line
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/agent-chat/index.ts
+++ b/src/components/agent-chat/index.ts
@@ -1,0 +1,6 @@
+export { AgentChat, type AgentChatProps } from "./agent-chat"
+export { MessageBubble } from "./message-bubble"
+export { ToolCallCard } from "./tool-call-card"
+export { MermaidBlock } from "./mermaid-block"
+export { JsonPreview } from "./json-preview"
+export type { UIMessage } from "@ai-sdk/react"

--- a/src/components/agent-chat/json-preview.tsx
+++ b/src/components/agent-chat/json-preview.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import { useState, useMemo } from "react"
+import { Check, ChevronDown, ChevronRight, Copy } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface JsonPreviewProps {
+  data: unknown
+  title?: string
+  className?: string
+}
+
+function JsonNode({ value, depth = 0 }: { value: unknown; depth?: number }) {
+  const [collapsed, setCollapsed] = useState(depth > 2)
+
+  if (value === null) return <span className="text-orange-400">null</span>
+  if (value === undefined) return <span className="text-muted-foreground">undefined</span>
+  if (typeof value === "boolean") return <span className="text-purple-400">{String(value)}</span>
+  if (typeof value === "number") return <span className="text-cyan-400">{value}</span>
+  if (typeof value === "string") {
+    if (value.length > 120) {
+      return <span className="text-green-400">&quot;{value.slice(0, 120)}...&quot;</span>
+    }
+    return <span className="text-green-400">&quot;{value}&quot;</span>
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return <span className="text-muted-foreground">[]</span>
+
+    return (
+      <span>
+        <button
+          onClick={() => setCollapsed(!collapsed)}
+          className="text-muted-foreground hover:text-foreground inline-flex items-center"
+        >
+          {collapsed ? <ChevronRight className="size-3" /> : <ChevronDown className="size-3" />}
+          <span className="text-xs">[{value.length}]</span>
+        </button>
+        {!collapsed && (
+          <div className="border-muted ml-4 border-l pl-2">
+            {value.map((item, i) => (
+              <div key={i} className="py-0.5">
+                <JsonNode value={item} depth={depth + 1} />
+                {i < value.length - 1 && <span className="text-muted-foreground">,</span>}
+              </div>
+            ))}
+          </div>
+        )}
+      </span>
+    )
+  }
+
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+    if (entries.length === 0) return <span className="text-muted-foreground">{"{}"}</span>
+
+    return (
+      <span>
+        <button
+          onClick={() => setCollapsed(!collapsed)}
+          className="text-muted-foreground hover:text-foreground inline-flex items-center"
+        >
+          {collapsed ? <ChevronRight className="size-3" /> : <ChevronDown className="size-3" />}
+          <span className="text-xs">{`{${entries.length}}`}</span>
+        </button>
+        {!collapsed && (
+          <div className="border-muted ml-4 border-l pl-2">
+            {entries.map(([key, val], i) => (
+              <div key={key} className="py-0.5">
+                <span className="text-blue-400">&quot;{key}&quot;</span>
+                <span className="text-muted-foreground">: </span>
+                <JsonNode value={val} depth={depth + 1} />
+                {i < entries.length - 1 && <span className="text-muted-foreground">,</span>}
+              </div>
+            ))}
+          </div>
+        )}
+      </span>
+    )
+  }
+
+  return <span>{String(value)}</span>
+}
+
+export function JsonPreview({ data, title, className }: JsonPreviewProps) {
+  const [copied, setCopied] = useState(false)
+  const jsonString = useMemo(() => JSON.stringify(data, null, 2), [data])
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(jsonString)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className={cn("overflow-hidden rounded-lg border", className)}>
+      <div className="bg-muted/50 flex items-center justify-between border-b px-3 py-1.5">
+        <span className="text-muted-foreground text-xs font-medium">{title ?? "JSON Output"}</span>
+        <Button variant="ghost" size="icon" className="size-6" onClick={handleCopy}>
+          {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+        </Button>
+      </div>
+      <div className="max-h-[500px] overflow-auto p-4 font-mono text-xs leading-relaxed">
+        <JsonNode value={data} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/agent-chat/mermaid-block.tsx
+++ b/src/components/agent-chat/mermaid-block.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { Check, Code, Copy, AlertCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface MermaidBlockProps {
+  code: string
+  className?: string
+}
+
+export function MermaidBlock({ code, className }: MermaidBlockProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [showRaw, setShowRaw] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [rendered, setRendered] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function render() {
+      if (!containerRef.current || showRaw) return
+
+      try {
+        // Dynamic import to avoid SSR issues
+        const mermaid = (await import("mermaid")).default
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: "dark",
+          securityLevel: "loose",
+        })
+
+        const id = `mermaid-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+        const { svg } = await mermaid.render(id, code.trim())
+
+        if (!cancelled && containerRef.current) {
+          containerRef.current.innerHTML = svg
+          setRendered(true)
+          setError(null)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to render diagram")
+          setShowRaw(true)
+        }
+      }
+    }
+
+    render()
+    return () => {
+      cancelled = true
+    }
+  }, [code, showRaw])
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className={cn("my-3 overflow-hidden rounded-lg border", className)}>
+      <div className="bg-muted/50 flex items-center justify-between border-b px-3 py-1.5">
+        <span className="text-muted-foreground text-xs font-medium">Mermaid Diagram</span>
+        <div className="flex gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6"
+            onClick={() => setShowRaw(!showRaw)}
+          >
+            <Code className="size-3" />
+          </Button>
+          <Button variant="ghost" size="icon" className="size-6" onClick={handleCopy}>
+            {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-destructive/5 text-destructive flex items-center gap-2 border-b px-3 py-2 text-xs">
+          <AlertCircle className="size-3" />
+          {error}
+        </div>
+      )}
+
+      {showRaw ? (
+        <pre className="overflow-x-auto p-4 text-xs">
+          <code>{code}</code>
+        </pre>
+      ) : (
+        <div ref={containerRef} className="flex justify-center overflow-x-auto p-4">
+          {!rendered && !error && (
+            <div className="text-muted-foreground text-sm">Rendering diagram...</div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/agent-chat/message-bubble.tsx
+++ b/src/components/agent-chat/message-bubble.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import { useState } from "react"
+import { Check, Copy } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface MessageBubbleProps {
+  role: "user" | "assistant"
+  content: string
+  timestamp?: string
+  className?: string
+}
+
+/** Render inline markdown: **bold**, `code`, and line breaks */
+function renderMarkdown(text: string): React.ReactNode[] {
+  return text.split("\n").map((line, i) => {
+    if (line.trim() === "") return <br key={i} />
+
+    // Split on bold (**text**) and inline code (`code`)
+    const parts = line.split(/(\*\*.*?\*\*|`[^`]+`)/g)
+    const rendered = parts.map((part, j) => {
+      if (part.startsWith("**") && part.endsWith("**")) {
+        return <strong key={j}>{part.slice(2, -2)}</strong>
+      }
+      if (part.startsWith("`") && part.endsWith("`")) {
+        return (
+          <code key={j} className="bg-muted rounded px-1 py-0.5 text-sm">
+            {part.slice(1, -1)}
+          </code>
+        )
+      }
+      return part
+    })
+
+    return (
+      <p key={i} className="mb-1 last:mb-0">
+        {rendered}
+      </p>
+    )
+  })
+}
+
+function formatTimestamp(ts: string): string {
+  try {
+    return new Date(ts).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    })
+  } catch {
+    return ""
+  }
+}
+
+export function MessageBubble({ role, content, timestamp, className }: MessageBubbleProps) {
+  const [copied, setCopied] = useState(false)
+  const isUser = role === "user"
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(content)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className={cn("group flex", isUser ? "justify-end" : "justify-start", className)}>
+      <div
+        className={cn(
+          "relative max-w-[85%] rounded-2xl px-4 py-3 text-sm leading-relaxed",
+          isUser ? "bg-primary text-primary-foreground" : "bg-muted text-foreground",
+        )}
+      >
+        <div className="whitespace-pre-wrap">{renderMarkdown(content)}</div>
+
+        <div className="mt-1.5 flex items-center justify-between gap-2">
+          {timestamp && (
+            <span
+              className={cn(
+                "text-xs",
+                isUser ? "text-primary-foreground/60" : "text-muted-foreground",
+              )}
+            >
+              {formatTimestamp(timestamp)}
+            </span>
+          )}
+
+          {!isUser && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-6 opacity-0 transition-opacity group-hover:opacity-100"
+              onClick={handleCopy}
+            >
+              {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/agent-chat/tool-call-card.tsx
+++ b/src/components/agent-chat/tool-call-card.tsx
@@ -11,13 +11,19 @@ interface ToolCallCardProps {
 }
 
 const TOOL_LABELS: Record<string, string> = {
+  // Career Interviewer
   save_work_experience: "Saving work experience",
   save_project: "Saving project",
-  save_skill_category: "Saving skills",
-  update_summary: "Updating summary",
-  analyze_jd: "Analyzing job description",
+  save_education: "Saving education",
+  save_skills: "Saving skills",
+  save_certification: "Saving certification",
+  get_existing_career_data: "Loading career data",
+  // Resume Tailor
+  analyze_job_description: "Analyzing job description",
+  match_resume_to_jd: "Matching resume to JD",
   generate_tailored_bullets: "Generating tailored bullets",
-  generate_full_resume: "Generating full resume",
+  save_job_analysis: "Saving job analysis",
+  update_resume_bullets: "Updating resume bullets",
 }
 
 function getToolLabel(toolName: string): string {

--- a/src/components/agent-chat/tool-call-card.tsx
+++ b/src/components/agent-chat/tool-call-card.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { Check, AlertCircle, Loader2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+interface ToolCallCardProps {
+  toolName: string
+  state: "partial-call" | "call" | "result"
+  output?: unknown
+  className?: string
+}
+
+const TOOL_LABELS: Record<string, string> = {
+  save_work_experience: "Saving work experience",
+  save_project: "Saving project",
+  save_skill_category: "Saving skills",
+  update_summary: "Updating summary",
+  analyze_jd: "Analyzing job description",
+  generate_tailored_bullets: "Generating tailored bullets",
+  generate_full_resume: "Generating full resume",
+}
+
+function getToolLabel(toolName: string): string {
+  return TOOL_LABELS[toolName] ?? toolName.replace(/_/g, " ")
+}
+
+export function ToolCallCard({ toolName, state, output, className }: ToolCallCardProps) {
+  const label = getToolLabel(toolName)
+  const isLoading = state === "partial-call" || state === "call"
+  const isSuccess = state === "result" && output !== undefined
+  const isError = state === "result" && output === undefined
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-lg border px-4 py-3 text-sm",
+        isLoading && "border-blue-500/30 bg-blue-500/5",
+        isSuccess && "border-green-500/30 bg-green-500/5",
+        isError && "border-destructive/30 bg-destructive/5",
+        className,
+      )}
+    >
+      {isLoading && <Loader2 className="size-4 animate-spin text-blue-500" />}
+      {isSuccess && <Check className="size-4 text-green-500" />}
+      {isError && <AlertCircle className="text-destructive size-4" />}
+
+      <span
+        className={cn(
+          isLoading && "text-blue-500",
+          isSuccess && "text-green-500",
+          isError && "text-destructive",
+        )}
+      >
+        {isLoading ? `${label}...` : isError ? `Failed: ${label}` : label}
+      </span>
+    </div>
+  )
+}

--- a/src/components/animations/TextReveal.tsx
+++ b/src/components/animations/TextReveal.tsx
@@ -45,6 +45,7 @@ export function TextReveal({
         type: type,
         mask: type === "lines" ? "lines" : undefined,
       })
+      el.removeAttribute("aria-label")
 
       const targets = type === "chars" ? split.chars : type === "words" ? split.words : split.lines
 

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -97,7 +97,6 @@ export function About({ aboutData: aboutDataProp }: AboutProps) {
                   fill
                   className="object-cover"
                   sizes="(max-width: 1024px) 100vw, 50vw"
-                  unoptimized
                 />
               ) : (
                 <div className="h-full w-full" />

--- a/src/components/sections/Credentials.tsx
+++ b/src/components/sections/Credentials.tsx
@@ -65,7 +65,6 @@ function EducationCard({ entry, index }: { entry: EducationItem; index: number }
                 width={40}
                 height={40}
                 className="rounded-lg object-contain"
-                unoptimized
               />
             ) : (
               <GraduationCap className="text-primary h-7 w-7" />
@@ -130,7 +129,6 @@ function CertificationBadge({ cert, index }: { cert: CertificationItem; index: n
               width={56}
               height={56}
               className="rounded-lg object-contain"
-              unoptimized
             />
           ) : (
             <div className="bg-primary/10 flex h-14 w-14 items-center justify-center rounded-xl">

--- a/src/components/sections/Experience.tsx
+++ b/src/components/sections/Experience.tsx
@@ -53,7 +53,6 @@ function PhaseEntry({ phase, isLast }: { phase: RolePhase; isLast: boolean }) {
                   width={14}
                   height={14}
                   className="rounded-sm object-contain"
-                  unoptimized
                 />
               )}
               {phase.viaCompany}
@@ -117,7 +116,6 @@ function TimelineEntry({ entry, index }: { entry: ExperienceGroup; index: number
                     width={44}
                     height={44}
                     className="rounded-lg object-contain"
-                    unoptimized
                   />
                 ) : (
                   <Briefcase className="text-primary h-7 w-7" />
@@ -131,7 +129,6 @@ function TimelineEntry({ entry, index }: { entry: ExperienceGroup; index: number
                     width={18}
                     height={18}
                     className="rounded-full object-contain"
-                    unoptimized
                   />
                 </div>
               )}
@@ -179,7 +176,6 @@ function TimelineEntry({ entry, index }: { entry: ExperienceGroup; index: number
                             width={14}
                             height={14}
                             className="rounded-sm object-contain"
-                            unoptimized
                           />
                         )}
                         {entry.phases[0].viaCompany}

--- a/src/components/sections/Footer.tsx
+++ b/src/components/sections/Footer.tsx
@@ -124,7 +124,7 @@ export function Footer({ siteConfig: siteConfigProp, navLinks, venturesData = []
           {/* Nav columns */}
           <div className="flex gap-16">
             <div>
-              <p className="text-muted-foreground/60 mb-3 text-xs font-semibold tracking-widest uppercase">
+              <p className="text-muted-foreground mb-3 text-xs font-semibold tracking-widest uppercase">
                 Navigate
               </p>
               <nav className="flex flex-col gap-2.5">
@@ -138,7 +138,7 @@ export function Footer({ siteConfig: siteConfigProp, navLinks, venturesData = []
               </nav>
             </div>
             <div>
-              <p className="text-muted-foreground/60 mb-3 text-xs font-semibold tracking-widest uppercase">
+              <p className="text-muted-foreground mb-3 text-xs font-semibold tracking-widest uppercase">
                 More
               </p>
               <nav className="flex flex-col gap-2.5">
@@ -153,7 +153,7 @@ export function Footer({ siteConfig: siteConfigProp, navLinks, venturesData = []
             </div>
             {socials.length > 0 && (
               <div>
-                <p className="text-muted-foreground/60 mb-3 text-xs font-semibold tracking-widest uppercase">
+                <p className="text-muted-foreground mb-3 text-xs font-semibold tracking-widest uppercase">
                   Social
                 </p>
                 <nav className="flex flex-col gap-2.5">
@@ -173,7 +173,7 @@ export function Footer({ siteConfig: siteConfigProp, navLinks, venturesData = []
             )}
             {venturesData.length > 0 && (
               <div>
-                <p className="text-muted-foreground/60 mb-3 text-xs font-semibold tracking-widest uppercase">
+                <p className="text-muted-foreground mb-3 text-xs font-semibold tracking-widest uppercase">
                   Ventures
                 </p>
                 <nav className="flex flex-col gap-2.5">

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,13 +1,8 @@
 "use client"
 
-import { useRef, useEffect, useState } from "react"
-import gsap from "gsap"
-import { SplitText } from "gsap/SplitText"
-import { useGSAP } from "@gsap/react"
+import { useRef, useEffect, useState, useMemo } from "react"
 import { MagneticButton } from "@/components/animations/MagneticButton"
-import { useMousePosition } from "@/hooks/useMousePosition"
-
-gsap.registerPlugin(SplitText)
+import { useParallaxOnMouse } from "@/hooks/useMousePosition"
 
 interface HeroProps {
   heroData: {
@@ -84,20 +79,43 @@ export function Hero({ heroData: heroDataProp, siteConfig: siteConfigProp }: Her
   const taglineRef = useRef<HTMLParagraphElement>(null)
   const ctaRef = useRef<HTMLDivElement>(null)
   const floatingRef = useRef<HTMLDivElement>(null)
+  const blob1Ref = useRef<HTMLDivElement>(null)
+  const blob2Ref = useRef<HTMLDivElement>(null)
+  const blob3Ref = useRef<HTMLDivElement>(null)
   const [roleIndex, setRoleIndex] = useState(0)
-  const mouse = useMousePosition()
 
-  // Main entrance animation
-  useGSAP(
-    () => {
+  const parallaxTargets = useMemo(
+    () => [
+      { ref: blob1Ref, x: 20, y: 20 },
+      { ref: blob2Ref, x: -15, y: -15 },
+      { ref: blob3Ref, x: 10, y: 10 },
+    ],
+    [],
+  )
+  useParallaxOnMouse(parallaxTargets)
+
+  // Main entrance animation — dynamically import GSAP to defer parsing off critical path
+  useEffect(() => {
+    let cancelled = false
+
+    const initAnimation = async () => {
+      const [{ default: gsap }, { SplitText }] = await Promise.all([
+        import("gsap"),
+        import("gsap/SplitText"),
+      ])
+      gsap.registerPlugin(SplitText)
+
+      if (cancelled || !sectionRef.current) return
+
       const tl = gsap.timeline({ delay: 0.3 })
 
       // Greeting — set parent visible then animate chars
-      const greetingEl = document.querySelector(".hero-greeting") as HTMLElement
+      const greetingEl = sectionRef.current.querySelector(".hero-greeting") as HTMLElement
       if (greetingEl) greetingEl.style.opacity = "1"
       const greetingSplit = SplitText.create(".hero-greeting", {
         type: "chars",
       })
+      greetingEl?.removeAttribute("aria-label")
       tl.fromTo(
         greetingSplit.chars,
         { opacity: 0, y: 30, rotateX: 40 },
@@ -112,9 +130,10 @@ export function Hero({ heroData: heroDataProp, siteConfig: siteConfigProp }: Her
       )
 
       // Name — set parent visible, apply gradient to each char, then animate
-      const nameEl = document.querySelector(".hero-name") as HTMLElement
+      const nameEl = sectionRef.current.querySelector(".hero-name") as HTMLElement
       if (nameEl) nameEl.style.opacity = "1"
       const nameSplit = SplitText.create(".hero-name", { type: "chars" })
+      nameEl?.removeAttribute("aria-label")
       // Apply gradient to each char since background-clip:text doesn't inherit
       ;(nameSplit.chars as HTMLElement[]).forEach((char) => {
         char.style.background = "linear-gradient(135deg, oklch(0.7 0.25 264), oklch(0.7 0.2 330))"
@@ -150,6 +169,7 @@ export function Hero({ heroData: heroDataProp, siteConfig: siteConfigProp }: Her
         const taglineSplit = SplitText.create(taglineRef.current, {
           type: "words",
         })
+        taglineRef.current.removeAttribute("aria-label")
         tl.fromTo(
           taglineSplit.words,
           { opacity: 0, y: 20 },
@@ -185,9 +205,13 @@ export function Hero({ heroData: heroDataProp, siteConfig: siteConfigProp }: Her
         },
         "-=0.5",
       )
-    },
-    { scope: sectionRef },
-  )
+    }
+
+    initAnimation()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   // Rotating role text
   useEffect(() => {
@@ -220,28 +244,19 @@ export function Hero({ heroData: heroDataProp, siteConfig: siteConfigProp }: Her
       {/* Floating elements with parallax */}
       <div ref={floatingRef} className="absolute inset-0 -z-[5] overflow-hidden" aria-hidden="true">
         <div
-          className="hero-float absolute top-[15%] left-[10%] h-72 w-72 rounded-full opacity-20 blur-3xl"
-          style={{
-            background: "oklch(0.7 0.25 264 / 40%)",
-            transform: `translate(${mouse.normalizedX * 20}px, ${mouse.normalizedY * 20}px)`,
-            transition: "transform 0.3s ease-out",
-          }}
+          ref={blob1Ref}
+          className="hero-float absolute top-[15%] left-[10%] h-72 w-72 rounded-full opacity-20 blur-3xl will-change-transform"
+          style={{ background: "oklch(0.7 0.25 264 / 40%)" }}
         />
         <div
-          className="hero-float absolute right-[15%] bottom-[20%] h-96 w-96 rounded-full opacity-15 blur-3xl"
-          style={{
-            background: "oklch(0.7 0.2 330 / 30%)",
-            transform: `translate(${mouse.normalizedX * -15}px, ${mouse.normalizedY * -15}px)`,
-            transition: "transform 0.3s ease-out",
-          }}
+          ref={blob2Ref}
+          className="hero-float absolute right-[15%] bottom-[20%] h-96 w-96 rounded-full opacity-15 blur-3xl will-change-transform"
+          style={{ background: "oklch(0.7 0.2 330 / 30%)" }}
         />
         <div
-          className="hero-float absolute top-[40%] right-[30%] h-48 w-48 rounded-full opacity-10 blur-3xl"
-          style={{
-            background: "oklch(0.65 0.2 160 / 30%)",
-            transform: `translate(${mouse.normalizedX * 10}px, ${mouse.normalizedY * 10}px)`,
-            transition: "transform 0.3s ease-out",
-          }}
+          ref={blob3Ref}
+          className="hero-float absolute top-[40%] right-[30%] h-48 w-48 rounded-full opacity-10 blur-3xl will-change-transform"
+          style={{ background: "oklch(0.65 0.2 160 / 30%)" }}
         />
       </div>
 

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -107,7 +107,7 @@ function ProjectCard({
               alt={project.title}
               fill
               className="object-cover transition-transform duration-500 group-hover:scale-105"
-              unoptimized
+              sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
             />
           ) : (
             <div
@@ -219,7 +219,7 @@ function ProjectModal({ project, onClose }: { project: Project; onClose: () => v
               alt={project.title}
               fill
               className="object-cover"
-              unoptimized
+              sizes="(max-width: 896px) 100vw, 896px"
             />
           ) : (
             <div
@@ -335,7 +335,7 @@ function ProjectModal({ project, onClose }: { project: Project; onClose: () => v
                   width={800}
                   height={500}
                   className="w-full object-contain"
-                  unoptimized
+                  sizes="(max-width: 896px) 100vw, 800px"
                 />
               </div>
             </div>
@@ -361,7 +361,7 @@ function ProjectModal({ project, onClose }: { project: Project; onClose: () => v
                       width={400}
                       height={250}
                       className="w-full object-cover transition-transform duration-300 group-hover/img:scale-105"
-                      unoptimized
+                      sizes="(max-width: 640px) 100vw, 400px"
                     />
                     {project.imageCaptions[img] && (
                       <p className="text-muted-foreground px-3 py-2 text-xs">
@@ -522,7 +522,7 @@ function ProjectModal({ project, onClose }: { project: Project; onClose: () => v
               height={800}
               className="max-h-[85vh] max-w-[90vw] rounded-lg object-contain"
               onClick={(e) => e.stopPropagation()}
-              unoptimized
+              sizes="90vw"
             />
 
             {/* Caption */}

--- a/src/components/sections/Ventures.tsx
+++ b/src/components/sections/Ventures.tsx
@@ -68,7 +68,6 @@ export function Ventures({ venturesData }: VenturesProps) {
                             width={280}
                             height={80}
                             className="max-h-20 max-w-full object-contain"
-                            unoptimized
                           />
                         </div>
                         <div className="hidden dark:block">
@@ -78,7 +77,6 @@ export function Ventures({ venturesData }: VenturesProps) {
                             width={280}
                             height={80}
                             className="max-h-20 max-w-full object-contain"
-                            unoptimized
                           />
                         </div>
                       </>
@@ -89,7 +87,6 @@ export function Ventures({ venturesData }: VenturesProps) {
                         width={280}
                         height={80}
                         className="max-h-20 max-w-full object-contain"
-                        unoptimized
                       />
                     ) : (
                       <div className="bg-primary/10 flex h-20 w-20 items-center justify-center rounded-2xl">

--- a/src/hooks/useMousePosition.ts
+++ b/src/hooks/useMousePosition.ts
@@ -1,35 +1,43 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useEffect, type RefObject } from "react"
 
-interface MousePosition {
+interface ParallaxTarget {
+  ref: RefObject<HTMLElement | null>
+  /** Horizontal movement multiplier in pixels */
   x: number
+  /** Vertical movement multiplier in pixels */
   y: number
-  normalizedX: number
-  normalizedY: number
 }
 
-export function useMousePosition(): MousePosition {
-  const [position, setPosition] = useState<MousePosition>({
-    x: 0,
-    y: 0,
-    normalizedX: 0,
-    normalizedY: 0,
-  })
-
-  const handleMouseMove = useCallback((e: MouseEvent) => {
-    setPosition({
-      x: e.clientX,
-      y: e.clientY,
-      normalizedX: (e.clientX / window.innerWidth - 0.5) * 2,
-      normalizedY: (e.clientY / window.innerHeight - 0.5) * 2,
-    })
-  }, [])
-
+/**
+ * Applies parallax transforms to elements based on mouse position.
+ * Uses direct DOM manipulation instead of React state to avoid re-renders.
+ */
+export function useParallaxOnMouse(targets: ParallaxTarget[]) {
   useEffect(() => {
-    window.addEventListener("mousemove", handleMouseMove, { passive: true })
-    return () => window.removeEventListener("mousemove", handleMouseMove)
-  }, [handleMouseMove])
+    if (typeof window === "undefined") return
 
-  return position
+    let rafId: number
+
+    const handleMouseMove = (e: MouseEvent) => {
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(() => {
+        const nx = (e.clientX / window.innerWidth - 0.5) * 2
+        const ny = (e.clientY / window.innerHeight - 0.5) * 2
+
+        for (const { ref, x, y } of targets) {
+          if (ref.current) {
+            ref.current.style.transform = `translate(${nx * x}px, ${ny * y}px)`
+          }
+        }
+      })
+    }
+
+    window.addEventListener("mousemove", handleMouseMove, { passive: true })
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove)
+      cancelAnimationFrame(rafId)
+    }
+  }, [targets])
 }

--- a/src/lib/ai/context-builder.ts
+++ b/src/lib/ai/context-builder.ts
@@ -1,0 +1,88 @@
+import { getResumeWithRelations } from "@/lib/resume-builder/queries"
+import type { ResumeWithRelations } from "@/types/resume-builder"
+
+/**
+ * Build a structured career context string from a resume for AI agent consumption.
+ * Includes token budgeting to stay within reasonable context limits.
+ */
+export async function buildCareerContext(
+  resumeId: string,
+  maxChars: number = 8000,
+): Promise<string | null> {
+  const resume = await getResumeWithRelations(resumeId)
+  if (!resume) return null
+  return formatResumeContext(resume, maxChars)
+}
+
+export function formatResumeContext(resume: ResumeWithRelations, maxChars: number = 8000): string {
+  const sections: string[] = []
+
+  // Header
+  if (resume.contact_info?.full_name) {
+    sections.push(`<candidate_name>${resume.contact_info.full_name}</candidate_name>`)
+  }
+
+  // Summary
+  if (resume.summary?.text) {
+    sections.push(`<professional_summary>\n${resume.summary.text}\n</professional_summary>`)
+  }
+
+  // Work Experience — highest priority, most space
+  if (resume.work_experiences.length > 0) {
+    const expLines = resume.work_experiences.map((exp) => {
+      const dateRange = [exp.start_date, exp.end_date ?? "Present"].filter(Boolean).join(" — ")
+      const bullets = (exp.achievements ?? []).map((a) => `  - ${a.text}`).join("\n")
+      return `${exp.job_title} at ${exp.company}${exp.location ? ` (${exp.location})` : ""} [${dateRange}]\n${bullets}`
+    })
+    sections.push(`<work_experience>\n${expLines.join("\n\n")}\n</work_experience>`)
+  }
+
+  // Projects
+  if (resume.projects.length > 0) {
+    const projLines = resume.projects.map((proj) => {
+      const bullets = (proj.achievements ?? []).map((a) => `  - ${a.text}`).join("\n")
+      const desc = proj.description ? `: ${proj.description}` : ""
+      return `${proj.name}${desc}\n${bullets}`
+    })
+    sections.push(`<projects>\n${projLines.join("\n\n")}\n</projects>`)
+  }
+
+  // Skills
+  if (resume.skill_categories.length > 0) {
+    const skillLines = resume.skill_categories.map((cat) => `${cat.name}: ${cat.skills.join(", ")}`)
+    sections.push(`<skills>\n${skillLines.join("\n")}\n</skills>`)
+  }
+
+  // Education
+  if (resume.education.length > 0) {
+    const eduLines = resume.education.map((edu) => {
+      const parts = [
+        edu.degree,
+        edu.field_of_study ? `in ${edu.field_of_study}` : null,
+        `from ${edu.institution}`,
+        edu.graduation_date ? `(${edu.graduation_date})` : null,
+        edu.gpa ? `GPA: ${edu.gpa}` : null,
+        edu.honors ?? null,
+      ].filter(Boolean)
+      return parts.join(" ")
+    })
+    sections.push(`<education>\n${eduLines.join("\n")}\n</education>`)
+  }
+
+  // Certifications
+  if (resume.certifications.length > 0) {
+    const certLines = resume.certifications.map((c) => {
+      const parts = [c.name, c.issuer ? `(${c.issuer})` : null, c.date ?? null].filter(Boolean)
+      return parts.join(" ")
+    })
+    sections.push(`<certifications>\n${certLines.join("\n")}\n</certifications>`)
+  }
+
+  // Build and truncate
+  let result = sections.join("\n\n")
+  if (result.length > maxChars) {
+    result = result.slice(0, maxChars) + "\n... (truncated for token budget)"
+  }
+
+  return result
+}

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -1,0 +1,69 @@
+import { bedrock } from "./provider"
+
+/** Model metadata for the admin UI and cost-aware routing */
+export interface ModelInfo {
+  label: string
+  provider: "Anthropic" | "Amazon" | "Meta"
+  tier: "premium" | "standard" | "fast"
+  capabilities: ("tools" | "streaming" | "vision" | "reasoning")[]
+}
+
+/**
+ * Available models in the Bedrock catalog.
+ * Each agent pulls its model_id from the ai_prompts table,
+ * falling back to the default if not set.
+ */
+export const AVAILABLE_MODELS: Record<string, ModelInfo> = {
+  "us.anthropic.claude-sonnet-4-20250514-v1:0": {
+    label: "Claude Sonnet 4",
+    provider: "Anthropic",
+    tier: "premium",
+    capabilities: ["tools", "streaming", "vision", "reasoning"],
+  },
+  "us.anthropic.claude-3-5-sonnet-20241022-v2:0": {
+    label: "Claude 3.5 Sonnet v2",
+    provider: "Anthropic",
+    tier: "standard",
+    capabilities: ["tools", "streaming", "vision"],
+  },
+  "us.anthropic.claude-3-5-haiku-20241022-v1:0": {
+    label: "Claude 3.5 Haiku",
+    provider: "Anthropic",
+    tier: "fast",
+    capabilities: ["tools", "streaming"],
+  },
+  "amazon.nova-pro-v1:0": {
+    label: "Amazon Nova Pro",
+    provider: "Amazon",
+    tier: "standard",
+    capabilities: ["streaming"],
+  },
+  "meta.llama3-70b-instruct-v1:0": {
+    label: "Llama 3 70B",
+    provider: "Meta",
+    tier: "standard",
+    capabilities: ["streaming"],
+  },
+} as const
+
+export type ModelId = keyof typeof AVAILABLE_MODELS
+
+export const DEFAULT_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+
+/** Get a Bedrock model instance by ID, falling back to default */
+export function getModel(modelId?: string | null) {
+  const id = modelId ?? DEFAULT_MODEL_ID
+  return bedrock(id)
+}
+
+/** Get model metadata for display in admin UI */
+export function getModelInfo(modelId: string): ModelInfo | null {
+  return AVAILABLE_MODELS[modelId] ?? null
+}
+
+/** Get list of model IDs that support a specific capability */
+export function getModelsWithCapability(capability: ModelInfo["capabilities"][number]): string[] {
+  return Object.entries(AVAILABLE_MODELS)
+    .filter(([, info]) => info.capabilities.includes(capability))
+    .map(([id]) => id)
+}

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -1,0 +1,4 @@
+// Amazon Bedrock provider — zero-config
+// Auto-reads AWS_BEARER_TOKEN_BEDROCK from environment for Bearer token auth
+// Alternatively reads AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY + AWS_REGION for IAM auth
+export { bedrock } from "@ai-sdk/amazon-bedrock"

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -1,4 +1,8 @@
-// Amazon Bedrock provider — zero-config
+// Amazon Bedrock provider
 // Auto-reads AWS_BEARER_TOKEN_BEDROCK from environment for Bearer token auth
-// Alternatively reads AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY + AWS_REGION for IAM auth
-export { bedrock } from "@ai-sdk/amazon-bedrock"
+// Alternatively reads AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY for IAM auth
+import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock"
+
+export const bedrock = createAmazonBedrock({
+  region: process.env.AWS_REGION ?? "us-east-1",
+})

--- a/src/lib/ai/tools/career-interviewer.ts
+++ b/src/lib/ai/tools/career-interviewer.ts
@@ -1,0 +1,359 @@
+import { tool } from "ai"
+import { z } from "zod"
+import { createAdminClient } from "@/lib/supabase/admin"
+
+/**
+ * Career Interviewer Agent Tools
+ *
+ * These tools allow the Career Interviewer agent to autonomously save
+ * structured career data to the resume database as it interviews the user.
+ * Each tool maps directly to an existing resume builder DB table.
+ */
+
+/** Create tools bound to a specific resume ID */
+export function createInterviewerTools(resumeId: string) {
+  const supabase = createAdminClient()
+
+  return {
+    save_work_experience: tool({
+      description:
+        "Save a work experience entry with achievement bullet points to the user's resume. " +
+        "Use this after gathering sufficient details about a role including company, title, dates, and at least 2-3 XYZ-formula achievements.",
+      inputSchema: z.object({
+        job_title: z.string().describe("Job title (e.g. 'Senior Software Engineer')"),
+        company: z.string().describe("Company name"),
+        location: z.string().optional().describe("City, State or 'Remote'"),
+        start_date: z.string().optional().describe("Start date in YYYY-MM format (e.g. '2022-01')"),
+        end_date: z
+          .string()
+          .nullable()
+          .optional()
+          .describe("End date in YYYY-MM format, or null if current role"),
+        achievements: z
+          .array(z.string())
+          .min(1)
+          .describe(
+            "Achievement bullet points in XYZ formula: 'Accomplished [X] as measured by [Y] by doing [Z]'",
+          ),
+      }),
+      execute: async ({ job_title, company, location, start_date, end_date, achievements }) => {
+        // Get current max sort_order
+        const { data: existing } = await supabase
+          .from("resume_work_experiences")
+          .select("sort_order")
+          .eq("resume_id", resumeId)
+          .order("sort_order", { ascending: false })
+          .limit(1)
+
+        const nextOrder = (existing?.[0]?.sort_order ?? -1) + 1
+
+        // Insert work experience
+        const { data: exp, error: expError } = await supabase
+          .from("resume_work_experiences")
+          .insert({
+            resume_id: resumeId,
+            job_title,
+            company,
+            location: location ?? null,
+            start_date: start_date ?? null,
+            end_date: end_date ?? null,
+            sort_order: nextOrder,
+            is_visible: true,
+            is_promotion: false,
+          })
+          .select("id")
+          .single()
+
+        if (expError) return { success: false, error: expError.message }
+
+        // Insert achievements
+        const achievementRows = achievements.map((text, i) => ({
+          parent_id: exp.id,
+          parent_type: "work" as const,
+          text,
+          has_metric: /\d/.test(text),
+          sort_order: i,
+        }))
+
+        const { error: achError } = await supabase
+          .from("resume_achievements")
+          .insert(achievementRows)
+
+        if (achError) return { success: false, error: achError.message }
+
+        return {
+          success: true,
+          experience_id: exp.id,
+          message: `Saved ${job_title} at ${company} with ${achievements.length} bullet points.`,
+        }
+      },
+    }),
+
+    save_project: tool({
+      description:
+        "Save a project entry with description and achievement bullets to the user's resume. " +
+        "Use this after gathering project details including name, description, and impact metrics.",
+      inputSchema: z.object({
+        name: z.string().describe("Project name"),
+        description: z.string().optional().describe("Brief project description (1-2 sentences)"),
+        project_url: z.string().url().optional().describe("Live project URL"),
+        source_url: z.string().url().optional().describe("Source code URL (e.g. GitHub)"),
+        achievements: z
+          .array(z.string())
+          .min(1)
+          .describe("Achievement bullet points describing impact and technical details"),
+      }),
+      execute: async ({ name, description, project_url, source_url, achievements }) => {
+        const { data: existing } = await supabase
+          .from("resume_projects")
+          .select("sort_order")
+          .eq("resume_id", resumeId)
+          .order("sort_order", { ascending: false })
+          .limit(1)
+
+        const nextOrder = (existing?.[0]?.sort_order ?? -1) + 1
+
+        const { data: proj, error: projError } = await supabase
+          .from("resume_projects")
+          .insert({
+            resume_id: resumeId,
+            name,
+            description: description ?? null,
+            project_url: project_url ?? null,
+            source_url: source_url ?? null,
+            sort_order: nextOrder,
+          })
+          .select("id")
+          .single()
+
+        if (projError) return { success: false, error: projError.message }
+
+        const achievementRows = achievements.map((text, i) => ({
+          parent_id: proj.id,
+          parent_type: "project" as const,
+          text,
+          has_metric: /\d/.test(text),
+          sort_order: i,
+        }))
+
+        const { error: achError } = await supabase
+          .from("resume_achievements")
+          .insert(achievementRows)
+
+        if (achError) return { success: false, error: achError.message }
+
+        return {
+          success: true,
+          project_id: proj.id,
+          message: `Saved project "${name}" with ${achievements.length} bullet points.`,
+        }
+      },
+    }),
+
+    save_education: tool({
+      description:
+        "Save an education entry to the user's resume. " +
+        "Use this after gathering degree, institution, field of study, and graduation date.",
+      inputSchema: z.object({
+        degree: z.string().describe("Degree name (e.g. 'Bachelor of Science')"),
+        institution: z.string().describe("University or institution name"),
+        field_of_study: z.string().optional().describe("Major or field of study"),
+        graduation_date: z
+          .string()
+          .optional()
+          .describe("Graduation date in YYYY-MM format (e.g. '2020-05')"),
+        gpa: z.number().optional().describe("GPA if notable (e.g. 3.8)"),
+        honors: z.string().optional().describe("Honors or distinctions (e.g. 'Magna Cum Laude')"),
+        relevant_coursework: z.array(z.string()).optional().describe("List of relevant courses"),
+      }),
+      execute: async ({
+        degree,
+        institution,
+        field_of_study,
+        graduation_date,
+        gpa,
+        honors,
+        relevant_coursework,
+      }) => {
+        const { data: existing } = await supabase
+          .from("resume_education")
+          .select("sort_order")
+          .eq("resume_id", resumeId)
+          .order("sort_order", { ascending: false })
+          .limit(1)
+
+        const nextOrder = (existing?.[0]?.sort_order ?? -1) + 1
+
+        const { data: edu, error } = await supabase
+          .from("resume_education")
+          .insert({
+            resume_id: resumeId,
+            degree,
+            institution,
+            field_of_study: field_of_study ?? null,
+            graduation_date: graduation_date ?? null,
+            gpa: gpa ?? null,
+            honors: honors ?? null,
+            relevant_coursework: relevant_coursework ?? null,
+            sort_order: nextOrder,
+          })
+          .select("id")
+          .single()
+
+        if (error) return { success: false, error: error.message }
+
+        return {
+          success: true,
+          education_id: edu.id,
+          message: `Saved ${degree} from ${institution}.`,
+        }
+      },
+    }),
+
+    save_skills: tool({
+      description:
+        "Save a skill category with a list of skills to the user's resume. " +
+        "Use categories like 'Languages', 'Frameworks', 'Cloud & DevOps', 'Databases', etc.",
+      inputSchema: z.object({
+        category_name: z
+          .string()
+          .describe("Skill category name (e.g. 'Languages', 'Frameworks & Libraries')"),
+        skills: z
+          .array(z.string())
+          .min(1)
+          .describe("List of individual skills (e.g. ['TypeScript', 'Python', 'Go'])"),
+      }),
+      execute: async ({ category_name, skills }) => {
+        const { data: existing } = await supabase
+          .from("resume_skill_categories")
+          .select("sort_order")
+          .eq("resume_id", resumeId)
+          .order("sort_order", { ascending: false })
+          .limit(1)
+
+        const nextOrder = (existing?.[0]?.sort_order ?? -1) + 1
+
+        const { data: cat, error } = await supabase
+          .from("resume_skill_categories")
+          .insert({
+            resume_id: resumeId,
+            name: category_name,
+            skills,
+            sort_order: nextOrder,
+          })
+          .select("id")
+          .single()
+
+        if (error) return { success: false, error: error.message }
+
+        return {
+          success: true,
+          category_id: cat.id,
+          message: `Saved skill category "${category_name}" with ${skills.length} skills.`,
+        }
+      },
+    }),
+
+    save_certification: tool({
+      description:
+        "Save a certification to the user's resume. " +
+        "Use this for professional certifications like AWS Solutions Architect, PMP, etc.",
+      inputSchema: z.object({
+        name: z.string().describe("Certification name"),
+        issuer: z.string().optional().describe("Issuing organization (e.g. 'Amazon Web Services')"),
+        date: z.string().optional().describe("Date obtained in YYYY-MM format"),
+      }),
+      execute: async ({ name, issuer, date }) => {
+        const { data: existing } = await supabase
+          .from("resume_certifications")
+          .select("sort_order")
+          .eq("resume_id", resumeId)
+          .order("sort_order", { ascending: false })
+          .limit(1)
+
+        const nextOrder = (existing?.[0]?.sort_order ?? -1) + 1
+
+        const { data: cert, error } = await supabase
+          .from("resume_certifications")
+          .insert({
+            resume_id: resumeId,
+            name,
+            issuer: issuer ?? null,
+            date: date ?? null,
+            sort_order: nextOrder,
+          })
+          .select("id")
+          .single()
+
+        if (error) return { success: false, error: error.message }
+
+        return {
+          success: true,
+          certification_id: cert.id,
+          message: `Saved certification "${name}".`,
+        }
+      },
+    }),
+
+    get_existing_career_data: tool({
+      description:
+        "Query the user's existing career data to check for duplicates before saving. " +
+        "Always call this at the start of a session to understand what's already documented.",
+      inputSchema: z.object({
+        sections: z
+          .array(z.enum(["work_experiences", "projects", "education", "skills", "certifications"]))
+          .describe("Which sections to retrieve"),
+      }),
+      execute: async ({ sections }) => {
+        const result: Record<string, unknown> = {}
+
+        if (sections.includes("work_experiences")) {
+          const { data } = await supabase
+            .from("resume_work_experiences")
+            .select("id, job_title, company, start_date, end_date")
+            .eq("resume_id", resumeId)
+            .order("sort_order")
+          result.work_experiences = data ?? []
+        }
+
+        if (sections.includes("projects")) {
+          const { data } = await supabase
+            .from("resume_projects")
+            .select("id, name, description")
+            .eq("resume_id", resumeId)
+            .order("sort_order")
+          result.projects = data ?? []
+        }
+
+        if (sections.includes("education")) {
+          const { data } = await supabase
+            .from("resume_education")
+            .select("id, degree, institution, field_of_study")
+            .eq("resume_id", resumeId)
+            .order("sort_order")
+          result.education = data ?? []
+        }
+
+        if (sections.includes("skills")) {
+          const { data } = await supabase
+            .from("resume_skill_categories")
+            .select("id, name, skills")
+            .eq("resume_id", resumeId)
+            .order("sort_order")
+          result.skills = data ?? []
+        }
+
+        if (sections.includes("certifications")) {
+          const { data } = await supabase
+            .from("resume_certifications")
+            .select("id, name, issuer, date")
+            .eq("resume_id", resumeId)
+            .order("sort_order")
+          result.certifications = data ?? []
+        }
+
+        return result
+      },
+    }),
+  }
+}

--- a/src/lib/ai/tools/career-interviewer.ts
+++ b/src/lib/ai/tools/career-interviewer.ts
@@ -95,6 +95,10 @@ export function createInterviewerTools(resumeId: string) {
         "Use this after gathering project details including name, description, and impact metrics.",
       inputSchema: z.object({
         name: z.string().describe("Project name"),
+        company: z
+          .string()
+          .optional()
+          .describe("Company or organization this project was built for/at"),
         description: z.string().optional().describe("Brief project description (1-2 sentences)"),
         project_url: z.string().url().optional().describe("Live project URL"),
         source_url: z.string().url().optional().describe("Source code URL (e.g. GitHub)"),
@@ -103,7 +107,7 @@ export function createInterviewerTools(resumeId: string) {
           .min(1)
           .describe("Achievement bullet points describing impact and technical details"),
       }),
-      execute: async ({ name, description, project_url, source_url, achievements }) => {
+      execute: async ({ name, company, description, project_url, source_url, achievements }) => {
         const { data: existing } = await supabase
           .from("resume_projects")
           .select("sort_order")
@@ -118,6 +122,7 @@ export function createInterviewerTools(resumeId: string) {
           .insert({
             resume_id: resumeId,
             name,
+            company: company ?? null,
             description: description ?? null,
             project_url: project_url ?? null,
             source_url: source_url ?? null,
@@ -145,7 +150,7 @@ export function createInterviewerTools(resumeId: string) {
         return {
           success: true,
           project_id: proj.id,
-          message: `Saved project "${name}" with ${achievements.length} bullet points.`,
+          message: `Saved project "${name}"${company ? ` at ${company}` : ""} with ${achievements.length} bullet points.`,
         }
       },
     }),

--- a/src/lib/ai/tools/resume-tailor.ts
+++ b/src/lib/ai/tools/resume-tailor.ts
@@ -1,0 +1,172 @@
+import { tool } from "ai"
+import { z } from "zod"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { getResumeWithRelations } from "@/lib/resume-builder/queries"
+import { matchJobDescription, analyzeJobDescription } from "@/lib/resume-builder/ai/services"
+
+/**
+ * Resume Tailor Agent Tools
+ *
+ * These tools allow the Resume Tailor agent to analyze job descriptions,
+ * match them against a resume, and generate tailored bullet points.
+ */
+
+export function createTailorTools(resumeId: string) {
+  const supabase = createAdminClient()
+
+  return {
+    analyze_job_description: tool({
+      description:
+        "Analyze a job description to extract key skills, requirements, qualifications, experience level, and red flags. " +
+        "Use this when the user pastes a job description to understand what the role demands.",
+      inputSchema: z.object({
+        raw_text: z.string().describe("The full text of the job description"),
+      }),
+      execute: async ({ raw_text }) => {
+        const analysis = await analyzeJobDescription(raw_text)
+        return analysis
+      },
+    }),
+
+    match_resume_to_jd: tool({
+      description:
+        "Match the user's resume against a job description to calculate a match rate, " +
+        "identify present and missing keywords, and generate improvement suggestions. " +
+        "Use this after analyzing the job description.",
+      inputSchema: z.object({
+        job_description_text: z.string().describe("The job description text to match against"),
+      }),
+      execute: async ({ job_description_text }) => {
+        const resume = await getResumeWithRelations(resumeId)
+        if (!resume) return { error: "Resume not found" }
+        const matchResult = await matchJobDescription(resume, job_description_text)
+        return matchResult
+      },
+    }),
+
+    generate_tailored_bullets: tool({
+      description:
+        "Generate tailored resume bullet points that mirror the terminology from a job description " +
+        "while preserving factual accuracy from the user's actual experience. " +
+        "Always uses XYZ formula: 'Accomplished [X] as measured by [Y] by doing [Z]'.",
+      inputSchema: z.object({
+        experience_context: z
+          .string()
+          .describe("The original experience description or bullet points to rewrite"),
+        target_keywords: z
+          .array(z.string())
+          .describe("Keywords from the JD to mirror in the rewritten bullets"),
+        count: z.number().min(1).max(10).default(5).describe("Number of bullet points to generate"),
+      }),
+      execute: async ({ experience_context, target_keywords, count }) => {
+        // This tool returns instructions for the LLM to generate bullets
+        // The actual generation happens in the LLM's response
+        return {
+          instruction:
+            "Generate the tailored bullets in your response text. " +
+            "Mirror these keywords where factually accurate: " +
+            target_keywords.join(", "),
+          source_experience: experience_context,
+          requested_count: count,
+        }
+      },
+    }),
+
+    save_job_analysis: tool({
+      description:
+        "Save a job description analysis to the database for future reference. " +
+        "Use this after completing the analysis.",
+      inputSchema: z.object({
+        title: z.string().describe("Job title"),
+        company: z.string().optional().describe("Company name"),
+        raw_text: z.string().describe("Full job description text"),
+        extracted_skills: z.array(z.string()).describe("Extracted skills"),
+        extracted_requirements: z.array(z.string()).describe("Extracted requirements"),
+        extracted_qualifications: z.array(z.string()).describe("Extracted qualifications"),
+        experience_level: z.string().optional().describe("Detected experience level"),
+        summary: z.string().optional().describe("Brief summary of the role"),
+      }),
+      execute: async ({
+        title,
+        company,
+        raw_text,
+        extracted_skills,
+        extracted_requirements,
+        extracted_qualifications,
+        experience_level,
+        summary,
+      }) => {
+        // Get user ID from the resume
+        const { data: resume } = await supabase
+          .from("resumes")
+          .select("user_id")
+          .eq("id", resumeId)
+          .single()
+
+        const { data: jd, error } = await supabase
+          .from("job_descriptions")
+          .insert({
+            user_id: resume?.user_id ?? null,
+            title,
+            company: company ?? null,
+            raw_text,
+            extracted_skills,
+            extracted_requirements,
+            extracted_qualifications,
+            analysis: { experience_level, summary },
+          })
+          .select("id")
+          .single()
+
+        if (error) return { success: false, error: error.message }
+
+        return {
+          success: true,
+          jd_id: jd.id,
+          message: `Saved analysis for "${title}"${company ? ` at ${company}` : ""}.`,
+        }
+      },
+    }),
+
+    update_resume_bullets: tool({
+      description:
+        "Update achievement bullet points for an existing work experience or project on the resume. " +
+        "Use this to replace existing bullets with tailored versions. The user must confirm before saving.",
+      inputSchema: z.object({
+        parent_id: z.string().describe("The ID of the work experience or project to update"),
+        parent_type: z
+          .enum(["work", "project"])
+          .describe("Whether this is a work experience or project"),
+        new_bullets: z.array(z.string()).min(1).describe("The new tailored bullet points to save"),
+      }),
+      execute: async ({ parent_id, parent_type, new_bullets }) => {
+        // Delete existing achievements for this parent
+        const { error: delError } = await supabase
+          .from("resume_achievements")
+          .delete()
+          .eq("parent_id", parent_id)
+          .eq("parent_type", parent_type)
+
+        if (delError) return { success: false, error: delError.message }
+
+        // Insert new achievements
+        const rows = new_bullets.map((text, i) => ({
+          parent_id,
+          parent_type,
+          text,
+          has_metric: /\d/.test(text),
+          sort_order: i,
+        }))
+
+        const { error: insError } = await supabase.from("resume_achievements").insert(rows)
+
+        if (insError) return { success: false, error: insError.message }
+
+        return {
+          success: true,
+          message: `Updated ${new_bullets.length} bullet points for ${parent_type} entry.`,
+        }
+      },
+    }),
+  }
+}

--- a/src/types/ai-prompts.ts
+++ b/src/types/ai-prompts.ts
@@ -2,8 +2,10 @@ export interface AIPrompt {
   id: string
   slug: string
   name: string
-  category: "bullet" | "summary" | "description" | "general"
+  category: "bullet" | "summary" | "description" | "general" | "agent"
   description: string | null
+  persona_name: string | null
+  model_id: string | null
   system_prompt: string
   user_prompt_template: string
   model: string

--- a/src/types/resume-builder.ts
+++ b/src/types/resume-builder.ts
@@ -187,6 +187,7 @@ export interface ResumeProject {
   id: string
   resume_id: string
   name: string
+  company: string | null
   project_url: string | null
   source_url: string | null
   description: string | null

--- a/supabase/migrations/20260222290000_agent_personas.sql
+++ b/supabase/migrations/20260222290000_agent_personas.sql
@@ -1,0 +1,11 @@
+-- Multi-Agent System: extend ai_prompts for agent personas and model binding
+
+-- Add persona_name to identify agent-specific prompts
+ALTER TABLE ai_prompts ADD COLUMN IF NOT EXISTS persona_name TEXT;
+
+-- Add model_id for explicit model binding per agent
+ALTER TABLE ai_prompts ADD COLUMN IF NOT EXISTS model_id TEXT;
+
+-- Index for fast persona lookups
+CREATE INDEX IF NOT EXISTS idx_ai_prompts_persona
+  ON ai_prompts(persona_name) WHERE persona_name IS NOT NULL;

--- a/supabase/migrations/20260222300000_seed_agent_prompts.sql
+++ b/supabase/migrations/20260222300000_seed_agent_prompts.sql
@@ -1,0 +1,56 @@
+-- Seed the 3 agent system prompts + meta-prompt optimizer into ai_prompts
+
+INSERT INTO ai_prompts (slug, name, category, description, persona_name, model_id, system_prompt, user_prompt_template, model, max_tokens, is_default) VALUES
+(
+  'career_interviewer',
+  'Career Interviewer',
+  'agent',
+  'Elite Career Coach that iteratively interviews users and saves structured career data to the database via tool calls.',
+  'interviewer',
+  'us.anthropic.claude-sonnet-4-20250514-v1:0',
+  E'<role>\nYou are an elite Career Coach and Executive Hiring Manager with 15+ years of experience\nplacing candidates at FAANG, top startups, and Fortune 500 companies.\n</role>\n\n<objective>\nInterview me iteratively to build a comprehensive repository of my career directly into\nthe database. Your goal is to extract maximum-impact career data that produces\nATS-optimized, executive-quality resume content.\n</objective>\n\n<rules>\n1. ONE AT A TIME: Interview me about ONE company, role, or project at a time. Never ask\n   more than 2 questions per message.\n2. ADAPTIVE PROBING: Before each question, silently assess what''s missing from the 4\n   impact categories:\n   - Scale (users, revenue, team size, data volume)\n   - Speed (time saved, delivery acceleration, latency reduction)\n   - Quality (error reduction, uptime improvement, test coverage)\n   - Cost (infrastructure savings, headcount efficiency, budget optimization)\n3. PUSH BACK: If I give vague answers like "I improved performance," demand specifics:\n   "What was the before/after metric? What tools did you use? How many users were affected?"\n4. XYZ FORMULA: Transform all achievements into the XYZ format before saving:\n   "Accomplished [X impact] as measured by [Y metric] by doing [Z action]"\n5. AUTONOMOUS SAVING: Once you have sufficient structured data for a role/project,\n   trigger the appropriate save tool WITHOUT asking permission. Confirm what you saved\n   after the fact.\n6. DEDUPLICATION: Check the existing_career_data context to avoid saving duplicate entries.\n</rules>\n\nBegin every new chat by asking which company or project we are documenting today.',
+  'Interview me about my career experience.',
+  'claude-sonnet-4-6',
+  4096,
+  true
+),
+(
+  'enterprise_architect',
+  'Enterprise Architect',
+  'agent',
+  'Veteran Systems Engineering Agent that brainstorms system designs and outputs Mermaid.js architecture diagrams.',
+  'architect',
+  'us.anthropic.claude-sonnet-4-20250514-v1:0',
+  E'<role>\nYou are a Veteran Systems Engineering Agent and Enterprise Architect with 20+ years of\nexperience designing highly scalable, distributed systems across cloud platforms\n(AWS, GCP, Azure).\n</role>\n\n<objective>\nConceptualize enterprise-grade architectures based on my descriptions and translate them\ninto visual Mermaid.js diagrams.\n</objective>\n\n<rules>\n1. ANALYZE BEFORE DIAGRAMMING: When I describe a system, evaluate for:\n   - Single points of failure\n   - Scalability bottlenecks\n   - Security gaps (authentication, encryption, network isolation)\n   - Cost optimization opportunities\n2. ADVISE FIRST: Proactively suggest 1-2 high-impact improvements. Wait for my approval\n   before finalizing the diagram.\n3. MERMAID ONLY: Output exclusively in mermaid code blocks. No PlantUML or ASCII art.\n4. DIAGRAM QUALITY:\n   - Always use subgraph to group logical components (VPCs, services, data layers)\n   - Label all edges with protocols: -->|HTTPS|, -->|gRPC|, -->|WebSocket|, -->|SQL|\n   - Use consistent node shapes: databases as [(db)], services as [service],\n     queues as {{queue}}\n   - Ensure zero syntax errors.\n5. ITERATE: After presenting a diagram, ask if I want to zoom into a specific component,\n   add failure modes, or explore alternatives.\n</rules>\n\n<output_format>\nAll architecture outputs must be in mermaid code blocks. Accompany each diagram with a\nbrief (2-3 sentence) explanation of the key design decisions.\n</output_format>\n\nBegin every new chat by asking what system or architecture we are designing today.',
+  'Design a system architecture for me.',
+  'claude-sonnet-4-6',
+  4096,
+  true
+),
+(
+  'resume_tailor',
+  'Resume Tailor',
+  'agent',
+  'Executive Resume Writer that tailors career history to specific job descriptions with ATS optimization.',
+  'tailor',
+  'us.anthropic.claude-sonnet-4-20250514-v1:0',
+  E'<role>\nYou are an Executive Resume Writer and Career Strategist with expertise in ATS\noptimization. You have full access to the user''s factual career history via the\nprovided context.\n</role>\n\n<objective>\nTailor existing experience to specific job descriptions, ensuring high ATS match rates\nwithout fabricating information.\n</objective>\n\n<rules>\n1. STRICT FACTUAL ACCURACY: Use ONLY data from the provided career context. Never\n   hallucinate, invent, or exaggerate experience. If the user lacks a required skill,\n   flag it as a gap — do not fabricate it.\n2. VOCABULARY MIRRORING: Cross-reference existing bullet points against the target JD.\n   Rewrite bullets to mirror the exact terminology and keywords from the JD while\n   preserving factual accuracy.\n3. XYZ FORMULA: All bullets must follow: "Accomplished [X] as measured by [Y] by doing [Z]"\n4. PRIORITIZATION: Lead with the most JD-relevant experiences. Reorder sections to\n   front-load matching skills.\n5. STRUCTURED OUTPUT: When generating full resumes or bullet sets, always use the\n   provided tool calls. Never output raw JSON in chat text.\n</rules>\n\n<commands>\n- /analyze [paste JD]: Extract top 5 technical skills, top 3 soft skills, and provide a\n  match rating (0-100%%) against the user''s profile.\n- /bullets: Generate 5-7 tailored bullet points for the most relevant roles.\n- /full: Generate a complete tailored resume using the generate_full_resume tool.\n- /gap: Identify missing skills and provide interview talking points to address them.\n</commands>\n\nBegin every new chat by asking the user to paste the target Job Description.',
+  'Tailor my resume to a job description.',
+  'claude-sonnet-4-6',
+  8192,
+  true
+),
+(
+  'meta_prompt_optimizer',
+  'Prompt Optimizer',
+  'agent',
+  'Meta-AI that restructures and optimizes system prompts for maximum AI compliance.',
+  'prompt_engineer',
+  'us.anthropic.claude-sonnet-4-20250514-v1:0',
+  E'<role>\nYou are an expert Prompt Engineer specializing in Claude system prompts.\n</role>\n\n<task>\nThe user will provide a draft system prompt. Restructure and optimize it for maximum AI compliance.\n</task>\n\n<rules>\n1. Use clear XML tags to separate role, objective, rules, and output_format sections.\n2. Add explicit constraints for edge cases the draft may have missed.\n3. Include a "begin by" instruction to anchor the AI''s first response.\n4. Remove ambiguity — replace vague instructions with specific, testable behaviors.\n5. Preserve the original intent and domain expertise completely.\n6. Do NOT add placeholder examples — only add examples if the original prompt warrants them.\n</rules>\n\n<output_format>\nReturn ONLY the perfected prompt text. No commentary, no markdown wrapping, no explanation.\n</output_format>',
+  '{{draft_prompt}}',
+  'claude-sonnet-4-6',
+  4096,
+  true
+)
+ON CONFLICT (slug) DO NOTHING;


### PR DESCRIPTION
## Summary

- **3 AI agents** (Career Interviewer, Enterprise Architect, Resume Tailor) + On-Demand Prompt Engineer with auto-optimization
- **Amazon Bedrock** via `@ai-sdk/amazon-bedrock` with zero-config Bearer token auth (`AWS_BEARER_TOKEN_BEDROCK`)
- **Vercel AI SDK v6** (`ai@6.0.97`) for streaming, tool calling, and `useChat()` on client
- **Per-agent model selection** from a 5-model registry with tier-based routing (premium/standard/fast)
- **Shared `AgentChat` component** reused across all 3 agents with Mermaid.js rendering, tool lifecycle cards, and JSON preview

### What's Included

**Phase 1 — Foundation**
- Vercel AI SDK + Amazon Bedrock provider installation
- Model registry with 5 Bedrock models and metadata
- Test API route for SDK verification

**Phase 2 — Shared Components**
- `AgentChat` — Core streaming chat with `useChat()` v6 API
- `MessageBubble` — Inline markdown rendering
- `ToolCallCard` — Tool execution lifecycle visualization
- `MermaidBlock` — Dynamic Mermaid.js diagram rendering
- `JsonPreview` — Collapsible JSON tree

**Phase 3 — Prompt Engineer Enhancement**
- DB migrations: `persona_name` + `model_id` columns on `ai_prompts`
- 4 agent system prompts seeded (interviewer, architect, tailor, optimizer)
- `autoOptimizePrompt()` server action using meta-AI
- Auto-Optimize button in prompt editor UI

**Phase 4 — Career Interviewer Agent**
- 6 Zod tool schemas: save_work_experience, save_project, save_education, save_skills, save_certification, get_existing_career_data
- Streaming API route with tool execution and deduplication context
- Career Coach UI refactored to `AgentChat` with tool result sidebar

**Phase 5 — Enterprise Architect Agent**
- New `/admin/architect` page with Mermaid diagram streaming
- Streaming API route with DB-driven prompts
- Added to admin sidebar navigation

**Phase 6 — Resume Tailor Agent**
- RAG context builder with token budgeting
- 5 tool schemas: analyze_job_description, match_resume_to_jd, generate_tailored_bullets, save_job_analysis, update_resume_bullets
- Streaming API route with career data context injection
- New `/admin/resume-builder/tailor` page with resume selector

## Test plan

- [ ] Set `AWS_BEARER_TOKEN_BEDROCK` env var and verify streaming works on `/api/agents/test`
- [ ] Test Career Coach: create session, select resume, verify tool calls save data to DB
- [ ] Test Architect: describe a system, verify Mermaid diagram renders inline
- [ ] Test Resume Tailor: paste JD, verify analysis + matching + bullet generation
- [ ] Test Prompt Engineer: Auto-Optimize button generates improved prompt
- [ ] Verify all 3 agent pages appear in admin sidebar
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Build succeeds (`npx next build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)